### PR TITLE
Fix Issue #16 By Not Eliminating All Whitespace

### DIFF
--- a/fbchat_muqit/_graphql.py
+++ b/fbchat_muqit/_graphql.py
@@ -7,7 +7,7 @@ from .models import FBchatException
 
 def split_json_objects(json_string: str)-> List[Dict[str, Any]]:
     # Remove very long spaces
-    json_string = "".join(json_string.split())
+    json_string = " ".join(json_string.split())
     # Json string contains list of json objects without the `[` and `]` 
 
     # We need to parse them into a list of Dict in order to use json.loads()


### PR DESCRIPTION
There is a specific issue (https://github.com/togashigreat/fbchat-muqit/issues/16) where fetchThreadMessages returns message objects where the text field has no whitespace, and that stems from this line.

The line currently removes all whitespace (splits on all whitespace and adds a null string to join them) 

My proposed change changes all whitespace to a single space, which abides by the documenting comment to remove long spaces, however, I do not understand the desire to make that adjustment, and would appreciate some clarification.

I am not sure what the intent behind "Remove very long spaces" is for the JSON payload. It seems to me that respecting the data as given is the best option.