### PR TITLE
Simple documentation fix

### DIFF
--- a/fbchat_muqit/n_client.py
+++ b/fbchat_muqit/n_client.py
@@ -936,7 +936,7 @@ class Client:
         thread_type=ThreadType.USER,
         is_gif=False,
     ):
-        """Deprecated. Don't use it use sendLocalFiles()"""
+        """Deprecated. Use `sendLocalFiles()` instead."""
         if is_gif:
             mimetype = "image/gif"
         else:


### PR DESCRIPTION
Rephrased improper sentence form of "Don't use it use sendLocalFiles()" to be more clearer.