### PR TITLE
feat: multi-account manager + persistent sessions + core fixes

### DIFF
--- a/fbchat_muqit/__init__.py
+++ b/fbchat_muqit/__init__.py
@@ -1,11 +1,11 @@
-
 from .state import State
 from .client import Client
-from .facebook.client import  FacebookClient
+from .manager import ClientManager
+from .storage import JsonSessionStorage, SessionStorage
+from .facebook.client import FacebookClient
 from .messenger.client import MessengerClient
 from .events.dispatcher import EventType, EventDispatcher, EventCallback
-from .models import * 
-
+from .models import *
 
 __title__ = "fbchat-muqit"
 __version__ = "1.2.1"
@@ -21,18 +21,18 @@ __email__ = "togashiyuuta1111@gmail.com"
 __all__ = [
     # Core classes
     "Client",
+    "ClientManager",
+    "JsonSessionStorage",
+    "SessionStorage",
     "State",
     "FacebookClient",
     "MessengerClient",
-    
     # Thread related
     "ThreadType",
     "ThreadFolder",
     "Thread",
-    
     # User
     "User",
-    
     # Attachments
     "Attachment",
     "AttachmentType",
@@ -55,7 +55,6 @@ __all__ = [
     "Media",
     "Image",
     "Dimension",
-    
     # Thread Actions
     "ApprovalMode",
     "ApprovalQueue",
@@ -81,17 +80,14 @@ __all__ = [
     "ThreadTheme",
     "MuteThread",
     "ForcedFetch",
-    
     # Typing
     "Typing",
-    
     # Timestamps
     "ReadReceipt",
     "DeliveryReceipt",
     "MarkFolderSeen",
     "MarkRead",
     "MarkUnread",
-    
     # Messages
     "Message",
     "Mention",
@@ -102,33 +98,26 @@ __all__ = [
     "MessageUnsend",
     "Reaction",
     "EmojiSize",
-    
     # Message Data
     "MessageData",
-    
     # Notifications
     "PokeNotification",
     "PageNotification",
     "FriendRequestState",
     "friendUpdated",
     "friendRequestList",
-    
     # Presence
     "Presence",
     "UserStatus",
-    
     # Themes
     "Theme",
     "AlternativeTheme",
     "Asset",
-
-    # Event 
+    # Event
     "EventType",
     "EventDispatcher",
     "EventCallback",
-
-    # Message Response 
+    # Message Response
     "MessageSearchStatus",
     "MessageSearchResult",
 ]
-

--- a/fbchat_muqit/client.py
+++ b/fbchat_muqit/client.py
@@ -1,4 +1,4 @@
-# fbchat_muqit/client.py 
+# fbchat_muqit/client.py
 # main client
 from __future__ import annotations
 
@@ -11,7 +11,8 @@ __all__ = ["Client"]
 
 import asyncio
 import sys
-from typing import Optional
+from typing import Awaitable, Callable, Optional
+from contextlib import suppress
 
 # Base Classes
 from .facebook.client import FacebookClient
@@ -25,38 +26,43 @@ from .logging.logger import FBChatLogger, setup_logger, disable_logging
 from .exception.errors import FBChatError
 from .models.deltas.parser import MessageParser, ParsedEvent
 
+
 class Client(EventDispatcher, FacebookClient, MessengerClient):
-        
+
     def __init__(
-            self,
-            cookies_file_path: str,
-            userAgent: Optional[str] = None,
-            proxy: Optional[str] = None,
-            log_level = "INFO",
-            disable_logs = False,
-            online = True
-            ):
-        
+        self,
+        cookies_file_path: str,
+        userAgent: Optional[str] = None,
+        proxy: Optional[str] = None,
+        log_level="INFO",
+        disable_logs=False,
+        online=True,
+        initial_state: Optional[State] = None,
+    ):
+
         self._setup_windows_compatibility()
         super().__init__()
 
         self._state: Optional[State] = None
+        self._initial_state: Optional[State] = initial_state
         self._uid: str = ""
         self._name: str = ""
         self._mqtt: Optional[Mqtt] = None
         self._parser = MessageParser(self.logger)
         self._realtime: Optional[FacebookRealtime] = None
         self._events_queue: asyncio.Queue[ParsedEvent] = asyncio.Queue(maxsize=1000)
+        self._dispatch_task: Optional[asyncio.Task[None]] = None
+        self._manager_route: Optional[Callable[..., Awaitable[None]]] = None
+        self._manager_client_id: str = ""
 
-        
         self._cookies_file_path = cookies_file_path
         self._userAgent = userAgent
         self._proxy = proxy
         self._online = online
         self.logger: FBChatLogger = setup_logger(log_level)
 
-        self._listening: bool = False 
-        
+        self._listening: bool = False
+
         if disable_logs:
             disable_logging()
 
@@ -64,16 +70,22 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
     def uid(self):
         """The Facebook user ID of the client."""
         return self._uid
+
     @property
     def name(self):
         """The Facebook name of the client."""
         return self._name
 
     async def __aenter__(self):
-     # Reopen session if it was closed
+        # Reopen session if it was closed
         if not self._state:
-            state: State = await State.from_json_cookies(self._cookies_file_path, self._userAgent ,self._proxy)
-            self._state = state 
+            if self._initial_state is not None:
+                self._state = self._initial_state
+                self._initial_state = None
+            else:
+                self._state = await State.from_json_cookies(
+                    self._cookies_file_path, self._userAgent, self._proxy
+                )
         # Refresh every 1 hour
         # self._state.enable_auto_refresh(interval=3600)
         # self.logger.debug("Started auto state refresh")
@@ -91,25 +103,35 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
             self.logger.info(f"Logged in as {self.name} ({self.uid})")
         return self
 
-
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         if self._state:
             await self._state.close()
-            self._state = None 
+            self._state = None
 
         await self.stop_listening()
+
+    async def dispatch(self, event_name: EventType, *args, **kwargs) -> None:
+        """Dispatch to :class:`ClientManager` listeners (if any) then normal client handlers."""
+        route = self._manager_route
+        cid = self._manager_client_id
+        if route is not None and cid:
+            await route(cid, event_name, *args)
+        await super().dispatch(event_name, *args, **kwargs)
 
     @staticmethod
     def _setup_windows_compatibility():
         # Setup Windows asyncio compatibility
-        if sys.platform == 'win32':
+        if sys.platform == "win32":
             try:
                 # Check current policy
                 current_policy = asyncio.get_event_loop_policy()
                 # Switch to SelectorEventLoop if using ProactorEventLoop
-                if hasattr(asyncio, 'WindowsProactorEventLoopPolicy') and \
-                   isinstance(current_policy, asyncio.WindowsProactorEventLoopPolicy):
-                    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+                if hasattr(asyncio, "WindowsProactorEventLoopPolicy") and isinstance(
+                    current_policy, asyncio.WindowsProactorEventLoopPolicy
+                ):
+                    asyncio.set_event_loop_policy(
+                        asyncio.WindowsSelectorEventLoopPolicy()
+                    )
                 # Ensure event loop exists
                 try:
                     asyncio.get_event_loop()
@@ -121,43 +143,53 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
 
     async def start_listening(self):
         """Start listening from an external event loop.
-        
+
         Raises:
             FBchatException: If request failed
         """
         if not self._state:
             raise FBChatError("Failed to get session")
-        
-        self._mqtt = await Mqtt.connect(
-                state=self._state,
-                chat_on=self._online,
-                foreground=self._online,
-                message_handler=self._handle_mqtt_messages
-            )
 
-        self._realtime = await FacebookRealtime.connect(self._state, self._handle_realtime_messages)
+        # Prevent duplicate task creation if caller re-enters start_listening().
+        if self._listening:
+            return
+
+        self._mqtt = await Mqtt.connect(
+            state=self._state,
+            chat_on=self._online,
+            foreground=self._online,
+            message_handler=self._handle_mqtt_messages,
+        )
+
+        self._realtime = await FacebookRealtime.connect(
+            self._state, self._handle_realtime_messages
+        )
 
         if self._online:
             await self._mqtt.set_chat_on(self._online)
             await self._mqtt.set_foreground(self._online)
         self._listening = True
         # starting dispatcher
-        asyncio.create_task(self._dispatch_mqtt_message())
-
+        self._dispatch_task = asyncio.create_task(self._dispatch_mqtt_message())
 
     async def stop_listening(self):
         """Stop the listening mqtt and realtime loop."""
+        self._listening = False
+
         if self._mqtt:
             await self._mqtt.stop()
         if self._realtime:
             await self._realtime.stop()
 
-        self._listening = False
+        if self._dispatch_task:
+            self._dispatch_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._dispatch_task
+            self._dispatch_task = None
         self._mqtt = None
         self._realtime = None
 
-
-    async def listen(self): 
+    async def listen(self):
         """Starts listening to events Blockingly"""
         await self.start_listening()
 
@@ -168,26 +200,28 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
                 await asyncio.sleep(3600)
         except asyncio.CancelledError:
             self.logger.debug("Client stopped listening!")
-            raise 
+            raise
 
         except Exception as e:
             self.logger.error(f"Error in listen loop: {e}")
             raise FBChatError("Listening failed", original_exception=e)
 
-    
     async def _dispatch_mqtt_message(self):
         """Dispatches Parsed Event data from Queue"""
-        while self._listening:
-            parsedEvent = await self._events_queue.get()
+        while True:
+            parsedEvent: Optional[ParsedEvent] = None
             try:
-                await self.dispatch(parsedEvent.eventType, *parsedEvent.args)
-            except Exception as e:
-                self.logger.error(f"Failed to dispatch Event ", exc_info=e)
-
+                parsedEvent = await self._events_queue.get()
+                if self._listening:
+                    await self.dispatch(parsedEvent.eventType, *parsedEvent.args)
+            except asyncio.CancelledError:
+                break
+            except Exception:
+                self.logger.error("Failed to dispatch Event ", exc_info=True)
             finally:
-                self._events_queue.task_done()
+                if parsedEvent is not None:
+                    self._events_queue.task_done()
 
-    
     async def _handle_mqtt_messages(self, topic: str, payload: bytes):
         """Handles and Parses incoming payloads and putting them in Queue"""
         try:
@@ -199,7 +233,7 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
                     fut.set_result(data)
                 return
 
-            elif topic == "/t_ms" and b'deltas' in payload:
+            elif topic == "/t_ms" and b"deltas" in payload:
                 try:
                     eventData = self._parser.parse_t_ms(payload)
                     for e in eventData:
@@ -212,13 +246,14 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
                 eventdata = self._parser.parse_all(topic, payload)
                 if eventdata:
                     await self._events_queue.put(eventdata)
-        except Exception as e:
-                self.logger.error(f"Failed to parse payloads ftom Topic: {topic} payload: {payload}", exc_info=e)
-    
-
+        except Exception:
+            self.logger.error(
+                f"Failed to parse payloads from Topic: {topic} (payload len={len(payload)})",
+                exc_info=True,
+            )
 
     async def _handle_realtime_messages(self, topic, payload):
-        pass 
+        pass
 
     async def start(self):
         """Initiates `Client` class and logins to account. But doesn't listens to event. To listen to events call `listen()` method."""
@@ -227,7 +262,6 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
     async def close(self):
         """Closes and clears all connections of Client"""
         await self.__aexit__(None, None, None)
-
 
     def run(self):
         """Blocking Call listens to incoming events"""
@@ -244,8 +278,6 @@ class Client(EventDispatcher, FacebookClient, MessengerClient):
             await self.listen()
         finally:
             await self.close()
-
-
 
     async def download(self, url: str, filename: str):
         """

--- a/fbchat_muqit/events/dispatcher.py
+++ b/fbchat_muqit/events/dispatcher.py
@@ -1,46 +1,48 @@
-
 import asyncio
 import inspect
-from typing import Awaitable, Callable, Dict, List
+from typing import Awaitable, Callable, Dict, List, Optional
 from enum import Enum
 from ..models.deltas.delta_wrapper import Typing
 
 from ..exception.errors import FBChatError
-from ..logging.logger import FBChatLogger, get_logger 
+from ..logging.logger import FBChatLogger, get_logger
 from ..models.message import Message, MessageReaction, MessageUnsend, MessageRemove
 from ..models.messagesData import MessageData
 from ..models.deltas.group_deltas import (
-        AdminAdded,
-        AdminRemoved, 
-        ApprovalMode,
-        ApprovalQueue,
-        ThreadDelete,
-        ThreadName,
-        ThreadNickname,
-        ThreadTheme,
-        ThreadEmoji,
-        ThreadMagicWord,
-        ThreadMessagePin,
-        ThreadMessageUnPin,
-        ThreadMessageSharing,
-        ThreadMuteSettings,
-        ThreadAction,
-        ParticipantsAdded, 
-        ParticipantLeft, 
-        )
+    AdminAdded,
+    AdminRemoved,
+    ApprovalMode,
+    ApprovalQueue,
+    ThreadDelete,
+    ThreadName,
+    ThreadNickname,
+    ThreadTheme,
+    ThreadEmoji,
+    ThreadMagicWord,
+    ThreadMessagePin,
+    ThreadMessageUnPin,
+    ThreadMessageSharing,
+    ThreadMuteSettings,
+    ThreadAction,
+    ParticipantsAdded,
+    ParticipantLeft,
+)
 
-from ..models.deltas.payloads import (
-        MuteThread,
-        ChangeViwerStatus,
-        PageNotification
-        )
+from ..models.deltas.payloads import MuteThread, ChangeViwerStatus, PageNotification
 
 from ..models.notifications import FriendRequestState, PokeNotification
 
-from ..models.timestamps import MarkUnread, ReadReceipt, MarkRead, DeliveryReceipt, MarkFolderSeen
+from ..models.timestamps import (
+    MarkUnread,
+    ReadReceipt,
+    MarkRead,
+    DeliveryReceipt,
+)
+
 
 class EventType(Enum):
     """Enum for all supported event types"""
+
     ADMIN_ADDED = "admin_added"
     ADMIN_REMOVED = "admin_removed"
 
@@ -51,7 +53,7 @@ class EventType(Enum):
     RECONNECT = "reconnect"
 
     MESSAGE = "message"
-    MESSAGE_UNSENT = "message_unsent" 
+    MESSAGE_UNSENT = "message_unsent"
     MESSAGE_REACTION = "message_reaction"
     MESSAGE_REMOVE = "message_remove"
     MESSAGE_SEEN = "message_seen"
@@ -91,8 +93,8 @@ class EventType(Enum):
     UNKNOWN = "unknown"
 
 
-
 EventCallback = Callable[..., Awaitable[None]]
+
 
 class EventDispatcher:
     def __init__(self, *args, **kwargs) -> None:
@@ -103,32 +105,47 @@ class EventDispatcher:
         self._semaphore = asyncio.Semaphore(self._max_concurrent_handlers)
         self._event_listeners: Dict[EventType, List[EventCallback]] = {}
 
-    def event(self, event_type):
-        # Decorator to register an event handler
-            
+    def event(self, event_type: Optional[EventType] = None):
+        """Register an event handler.
+
+        Supports ``@client.event`` and ``@client.event(EventType.X)``.
+        """
+
+        # Support ``@client.event`` usage where the decorated function is passed
+        # as the first argument.
+        if callable(event_type) and not isinstance(event_type, EventType):
+            func = event_type  # type: ignore[assignment]
+            return self.event(None)(func)  # type: ignore[misc]
+
+        if event_type is not None and not isinstance(event_type, EventType):
+            raise FBChatError("event_type must be an EventType")
+
         def decorator(func: EventCallback) -> EventCallback:
-            # Auto-detect event type from function name if not specified
-            if not event_type:
+            resolved: EventType
+
+            if event_type is None:
                 event_name = func.__name__
-                if not event_name.startswith('on_'):
-                    raise FBChatError(f"Event handler {event_name} must start with 'on_' or specify event_types")
-                
-                # Map function name to event type
+                if not event_name.startswith("on_"):
+                    raise FBChatError(
+                        f"Event handler {event_name} must start with 'on_' or be registered with an EventType"
+                    )
+
                 event_type_name = event_name[3:]
                 try:
-                    detected_type = EventType(event_type_name.lower())
-                    self.add_listener(detected_type, func)
-                except ValueError:
-                    raise FBChatError(f"Unknown event type: {event_type_name}")
+                    resolved = EventType(event_type_name.lower())
+                except ValueError as e:
+                    raise FBChatError(f"Unknown event type: {event_type_name}") from e
             else:
-                    self.add_listener(event_type, func)
-            return func
-        return decorator
+                resolved = event_type
 
+            self.add_listener(resolved, func)
+            return func
+
+        return decorator
 
     def add_listener(self, event_type: EventType, callback: EventCallback) -> None:
         """
-        Add an event listener for a specific event. 
+        Add an event listener for a specific event.
 
         Args:
             event_type (EventType): The type of the event you want to add listener for.
@@ -138,10 +155,10 @@ class EventDispatcher:
         if event_type not in self._event_listeners:
             self._event_listeners[event_type] = []
         self._event_listeners[event_type].append(callback)
-        
+
     def remove_listener(self, event_type: EventType, callback: EventCallback) -> bool:
         """
-        Remove an event listener for a specific event. 
+        Remove an event listener for a specific event.
 
         Args:
             event_type (EventType): The type of the event you want to remove listener for.
@@ -156,7 +173,6 @@ class EventDispatcher:
                 return False
         return False
 
-
     async def dispatch(self, event_name: EventType, *args, **kwargs) -> None:
         tasks = []
 
@@ -168,13 +184,14 @@ class EventDispatcher:
             listeners = list(listeners) + [getattr(self, method_name)]
 
         for listener in listeners:
-            tasks.append(asyncio.create_task(
-                self._safe_execute(listener, event_name, *args, **kwargs)
-            ))
+            tasks.append(
+                asyncio.create_task(
+                    self._safe_execute(listener, event_name, *args, **kwargs)
+                )
+            )
 
         if tasks:
             await asyncio.gather(*tasks)
-        
 
     async def _safe_execute(self, listener, event_name, *args, **kwargs):
         async with self._semaphore:
@@ -186,92 +203,95 @@ class EventDispatcher:
                     await asyncio.to_thread(listener, *args, **kwargs)
             except Exception as e:
                 self.logger.error(
-                    f"Error in event listener for {event_name}: {e}",
-                    exc_info=True
+                    f"Error in event listener for {event_name}: {e}", exc_info=True
                 )
-                    
+
     async def on_listening(self):
         """Called when the client starts listening to events"""
         self.logger.info(f"Client ({self._name}) started listening to Events!")
-
 
     async def on_admin_added(self, event_data: AdminAdded, message: MessageData):
         """
         Called when an admin is added to a messenger group.
 
         Args:
-            event_data (AdminsAdded): Receives a ``AdminsAdded`` object contains added admin id. 
-            message (MessageData): A `MessageData` object contains the message information meta data. 
+            event_data (AdminsAdded): Receives a ``AdminsAdded`` object contains added admin id.
+            message (MessageData): A `MessageData` object contains the message information meta data.
         """
-        self.logger.info(f"{message.sender_id} has promoted {event_data.aded_admin} to admin in thread {message.thread_id}")
+        self.logger.info(
+            f"{message.sender_id} has promoted {event_data.aded_admin} to admin in thread {message.thread_id}"
+        )
 
     async def on_admin_removed(self, event_data: AdminRemoved):
         """Called when an admin is removed from admin role.
-            
-            Args: 
-                event_data (AdminRemoved): Receives a ``AdminRemoved`` object.
-        """
-        self.logger.info(f"{event_data.messageMetadata.sender_id} has demoted {event_data.removed_admins} from admin role in Thread ({event_data.messageMetadata.thread_id})")
 
+        Args:
+            event_data (AdminRemoved): Receives a ``AdminRemoved`` object.
+        """
+        self.logger.info(
+            f"{event_data.messageMetadata.sender_id} has demoted {event_data.removed_admins} from admin role in Thread ({event_data.messageMetadata.thread_id})"
+        )
 
     async def on_approval_mode_change(self, event_data: ApprovalMode):
-        """Called when Approval mode is changed in a group. 
+        """Called when Approval mode is changed in a group.
 
-            Args:
-                event_data (ApprovalMode): Receives a ``ApprovalMode`` object.
+        Args:
+            event_data (ApprovalMode): Receives a ``ApprovalMode`` object.
         """
         self.logger.info(f"Approval mode is {event_data.mode}")
 
     async def on_approval_queue(self, event_data: ApprovalQueue):
         """Called when an user requests to join a group or invited by another participant of the group or disapproved a User's join request but approved join request information is not received.
 
-            Args:
-                event_data (ApprovalQueue): Receives a ``ApprovalQueue`` object.
+        Args:
+            event_data (ApprovalQueue): Receives a ``ApprovalQueue`` object.
         """
-        self.logger.info(f"{event_data.requester_id} has requested to join the thread {event_data.messageMetadata.thread_id}")
+        self.logger.info(
+            f"{event_data.requester_id} has requested to join the thread {event_data.messageMetadata.thread_id}"
+        )
 
     async def on_message_delivered(self, event_data: DeliveryReceipt):
         """Called when a message is successfully delivered to a thread.
-            
-        Args: 
+
+        Args:
             event_data (DeliveryReceipt): Receives a ``DeliveryReceipt`` object with delivery information.
         """
-        self.logger.info(f"The message {event_data.message_id} is delivered to Thread ({event_data.thread_id})")
+        self.logger.info(
+            f"The message {event_data.message_id} is delivered to Thread ({event_data.thread_id})"
+        )
 
-    async def on_mark_read (self, event_data: MarkRead):
+    async def on_mark_read(self, event_data: MarkRead):
         """Called when client marks a thread as read
-            
-        Args: 
+
+        Args:
             event_data (MarkRead): Receives a ``MarkRead`` object with read information.
         """
         self.logger.info(f"The Thread {event_data.thread_ids} marked as Read.")
-    
-    async def on_mark_unread (self, event_data: MarkUnread):
+
+    async def on_mark_unread(self, event_data: MarkUnread):
         """Called when client marks a thread as unread
-            
-        Args: 
+
+        Args:
             event_data (MarkUnread): Receives a ``MarkUnread`` object with read information.
         """
         self.logger.info(f"The Thread {event_data.thread_ids} marked as Unread.")
 
-
     async def on_message_removed(self, event_data: MessageRemove):
         """Called when the client removes a message for only itself
-        Args: 
+        Args:
             event_data (MessageRemove): A ``MessageRemove`` with additional information.
         """
         self.logger.info(f"Message {event_data.ids} has been removed for only client")
-
-        
 
     async def on_message(self, event_data: Message):
         """Called when a message received in messenger
 
         Args:
-            event_data (Message): A ``Message`` object contains the message information.            
+            event_data (Message): A ``Message`` object contains the message information.
         """
-        self.logger.info(f"{event_data.sender_id} has sent a message to thread {event_data.thread_id}")
-
+        self.logger.info(
+            f"{event_data.sender_id} has sent a message to thread {event_data.thread_id}"
+        )
 
     async def on_message_unsent(self, event_data: MessageUnsend):
         """Called when a message is unsent by a User.
@@ -281,53 +301,62 @@ class EventDispatcher:
         """
         self.logger.info(f"{event_data.sender_id} unsent the message {event_data.id}")
 
-
     async def on_message_reaction(self, event_data: MessageReaction):
-        """Called when an user reacts to a message 
+        """Called when an user reacts to a message
 
         Args:
-            event_data (MessageReaction): Receives a ``MessageReaction`` object. 
+            event_data (MessageReaction): Receives a ``MessageReaction`` object.
 
         """
-        self.logger.info(f"{event_data.reactor} {f'reacted with {event_data.reaction} to' if not event_data.reaction_type.value else f'removed reaction {event_data.reaction} from'}the message {event_data.id}")
-
+        self.logger.info(
+            f"{event_data.reactor} {f'reacted with {event_data.reaction} to' if not event_data.reaction_type.value else f'removed reaction {event_data.reaction} from'}the message {event_data.id}"
+        )
 
     async def on_message_seen(self, event_data: ReadReceipt):
         """Called when message is seen by an User.
 
-            Args:
-                event_data (ReadReceipt): Receives a ``ReadReceipt`` object.
+        Args:
+            event_data (ReadReceipt): Receives a ``ReadReceipt`` object.
         """
 
-        self.logger.info(f"{event_data.user_id} has seen messages in thread {event_data.thread_id}")
+        self.logger.info(
+            f"{event_data.user_id} has seen messages in thread {event_data.thread_id}"
+        )
 
-    async def on_message_pinned(self, event_data: ThreadMessagePin, message: MessageData):
+    async def on_message_pinned(
+        self, event_data: ThreadMessagePin, message: MessageData
+    ):
         """Called when a message gets pinned in a thread
 
-            Args:
-                event_data (ThreadMessagePin): Receives a ``ThreadMessagePin`` object.
-                message (MessageData): A ``MessageData`` object with message data.
+        Args:
+            event_data (ThreadMessagePin): Receives a ``ThreadMessagePin`` object.
+            message (MessageData): A ``MessageData`` object with message data.
         """
         self.logger.info(message.adminText)
 
-    async def on_message_unpinned(self, event_data: ThreadMessageUnPin, message: MessageData):
+    async def on_message_unpinned(
+        self, event_data: ThreadMessageUnPin, message: MessageData
+    ):
         """Called when a message gets unpinned in a thread
 
-            Args:
-                event_data (ThreadMessagePin): Receives a ``ThreadMessagePin`` object.
-                message (MessageData): A ``MessageData` object with message data.
+        Args:
+            event_data (ThreadMessagePin): Receives a ``ThreadMessagePin`` object.
+            message (MessageData): A ``MessageData` object with message data.
         """
         self.logger.info(message.adminText)
 
-    async def on_magic_words_change(self, event_data: ThreadMagicWord, message: MessageData):
+    async def on_magic_words_change(
+        self, event_data: ThreadMagicWord, message: MessageData
+    ):
         """Called when Magic words are added or removed in a group
 
-            Args:
-                event_data (UpdatedMagicWords): Receives a ``UpdatedMagicWords`` object.
-                message (MessageData): A ``MessageData`` object with message data.
+        Args:
+            event_data (UpdatedMagicWords): Receives a ``UpdatedMagicWords`` object.
+            message (MessageData): A ``MessageData`` object with message data.
         """
-        self.logger.info(f"Magic words {f'{event_data.emoji} added to' if int(event_data.new_magic_word_count) else f'{event_data.theme_name} {event_data.emoji} removed from'} thread {message.thread_id}")
-
+        self.logger.info(
+            f"Magic words {f'{event_data.emoji} added to' if int(event_data.new_magic_word_count) else f'{event_data.theme_name} {event_data.emoji} removed from'} thread {message.thread_id}"
+        )
 
     async def on_thread_mute(self, event_data: MuteThread):
         """Called when the client mutes a thread community/group.
@@ -335,7 +364,9 @@ class EventDispatcher:
         Args:
             event_data (MuteThread): Receives a ``MuteThread`` object.
         """
-        self.logger.info(f"Thread ({event_data.thread_id}) has muted for {'infinite time' if event_data.mute_until == -1 else event_data.mute_until}")
+        self.logger.info(
+            f"Thread ({event_data.thread_id}) has muted for {'infinite time' if event_data.mute_until == -1 else event_data.mute_until}"
+        )
 
     async def on_thread_mute_settings(self, event_data: ThreadMuteSettings):
         """Called when the client mutes a Thread.
@@ -343,43 +374,45 @@ class EventDispatcher:
         Args:
             event_data (ThreadMuteSettings): Receives a ``ThreadMuteSettings`` object.
         """
-        self.logger.info(f"{event_data.thread_id} has been muted by {event_data.user_id} for {event_data.expire_time} ms")
-
+        self.logger.info(
+            f"{event_data.thread_id} has been muted by {event_data.user_id} for {event_data.expire_time} ms"
+        )
 
     async def on_participant_joined(self, event_data: ParticipantsAdded):
         """Called when an user joins a messenger group/community
 
-            Args:
-                event_data (ParticipantsAdded): Receives a ``ParticipantsAdded`` object.
+        Args:
+            event_data (ParticipantsAdded): Receives a ``ParticipantsAdded`` object.
         """
         self.logger.info(event_data.messageMetadata.adminText)
-
 
     async def on_participant_left(self, event_data: ParticipantLeft):
         """Called when an user leaves or removed from a messenger group/community
 
-            Args:
-                event_data (ParticipantLeft): Receives a ``ParticipantLeft`` object.
+        Args:
+            event_data (ParticipantLeft): Receives a ``ParticipantLeft`` object.
         """
         self.logger.info(event_data.messageMetadata.adminText)
 
     async def on_page_notification(self, event_data: PageNotification):
-        """Called when a message is sent to a page that Client created. 
+        """Called when a message is sent to a page that Client created.
 
-            Args:
-                event_data (PageNotification): Receives a ``PageNotification`` object.
+        Args:
+            event_data (PageNotification): Receives a ``PageNotification`` object.
         """
-        self.logger.info(f"{event_data.sender_id} has a message to the Page ({event_data.page_id}) {event_data.page_name}")
-
+        self.logger.info(
+            f"{event_data.sender_id} has a message to the Page ({event_data.page_id}) {event_data.page_name}"
+        )
 
     async def on_typing(self, event_data: Typing):
         """Called When someone starts/stops typing
 
         Args:
-            event_data (Typing): Receives a ``Typing`` object. 
+            event_data (Typing): Receives a ``Typing`` object.
         """
-        self.logger.info(f"{event_data.sender_id} {'is typing' if event_data.state else 'stopped typing'} in thread {event_data.thread_id}")
-
+        self.logger.info(
+            f"{event_data.sender_id} {'is typing' if event_data.state else 'stopped typing'} in thread {event_data.thread_id}"
+        )
 
     async def on_thread_action(self, event_data: ThreadAction):
         """Called when client moves a Thread to archive/inbox.
@@ -387,7 +420,9 @@ class EventDispatcher:
         Args:
             event_data (ThreadAction): Receives a ``ThreadAction`` object.
         """
-        self.logger.info(f"Action on Thread: {event_data.thread_id} Action type: {event_data.action}")
+        self.logger.info(
+            f"Action on Thread: {event_data.thread_id} Action type: {event_data.action}"
+        )
 
     async def on_thread_delete(self, event_data: ThreadDelete):
         """Called when client deletes a Thread.
@@ -395,72 +430,89 @@ class EventDispatcher:
         Args:
             event_data (ThreadDelete): Receives a ``ThreadDelete`` object.
         """
-        self.logger.info(f"Client ({event_data.user_id}) has deleted Threads {event_data.thread_ids}")
-        
+        self.logger.info(
+            f"Client ({event_data.user_id}) has deleted Threads {event_data.thread_ids}"
+        )
 
     async def on_theme_change(self, event_data: ThreadTheme, message: MessageData):
         """Called when a thread's theme is changed.
 
-            Args:
-                event_data (ThreadTheme): Receives a ``ThreadTheme`` object.
-                message (MessageData): A ``MessageData`` object with message information.
+        Args:
+            event_data (ThreadTheme): Receives a ``ThreadTheme`` object.
+            message (MessageData): A ``MessageData`` object with message information.
         """
-        self.logger.info(f"Thread's ({message.thread_id}) theme changed to {event_data.theme_name} and Thread emoji changed to {event_data.theme_emoji}")
-    
+        self.logger.info(
+            f"Thread's ({message.thread_id}) theme changed to {event_data.theme_name} and Thread emoji changed to {event_data.theme_emoji}"
+        )
+
     async def on_thread_name_change(self, event_data: ThreadName):
         """Called when a thread's name is changed
 
-        Args: 
+        Args:
             event_data (UpdatedThreadName): Receives a ``UpdatedThreadName`` object.
         """
 
-        self.logger.info(f"{event_data.messageMetadata.sender_id} has changed thread's ({event_data.messageMetadata.thread_id}) name to {event_data.name}")
+        self.logger.info(
+            f"{event_data.messageMetadata.sender_id} has changed thread's ({event_data.messageMetadata.thread_id}) name to {event_data.name}"
+        )
 
     async def on_emoji_change(self, event_data: ThreadEmoji, message: MessageData):
         """Called when a thread's quick reaction emoji is changed.
 
-        Args: 
+        Args:
             event_data (UpdatedThreadEmoji): Receives a ``UpdatedThreadEmoji`` object.
         """
 
-        self.logger.info(f"Thread's {message.thread_id} quick reaction emoji has changed to {event_data.emoji}")
+        self.logger.info(
+            f"Thread's {message.thread_id} quick reaction emoji has changed to {event_data.emoji}"
+        )
 
-    async def on_nickname_change(self, event_data: ThreadNickname, message: MessageData):
+    async def on_nickname_change(
+        self, event_data: ThreadNickname, message: MessageData
+    ):
         """
-        Called when a User's nickname is changed in a thread. 
+        Called when a User's nickname is changed in a thread.
 
         Args:
             event_data (ThreadNickname): Receives a ``ThreadNickname`` object with user nickname change info.
         """
-        self.logger.info(f" User ({event_data.participant_id}) nickname changed to '{event_data.nickname}' in Thread ({message.thread_id})")
+        self.logger.info(
+            f" User ({event_data.participant_id}) nickname changed to '{event_data.nickname}' in Thread ({message.thread_id})"
+        )
 
-    async def on_message_sharing_change(self, event_data: ThreadMessageSharing, message: MessageData):
+    async def on_message_sharing_change(
+        self, event_data: ThreadMessageSharing, message: MessageData
+    ):
         """
-        Called when message sharing permission is changed in a thread. 
+        Called when message sharing permission is changed in a thread.
 
         Args:
             event_data (ThreadMessageSharing): Receives a ``ThreadMessageSharing`` object.
             message (MessageData): Receives a ``MessageData`` object with extra message info.
         """
-        self.logger.info(f"{event_data.sender_name} has updated message sharing mode to '{event_data.mode}' in Thread ({message.thread_id})")
-
+        self.logger.info(
+            f"{event_data.sender_name} has updated message sharing mode to '{event_data.mode}' in Thread ({message.thread_id})"
+        )
 
     async def on_viewer_status_change(self, event_data: ChangeViwerStatus):
         """Called when a Thread gets blocked on Facebook/Messenger
 
-        Args: 
+        Args:
             event_data (ChangeViwerStatus): Receives a ``ChangeViwerStatus`` object.
         """
-        self.logger.info(f"{event_data.thread_id} is blocked on {'Facebook' if event_data.is_facebook_blocked else 'Messenger'} by {event_data.user_id}")
+        self.logger.info(
+            f"{event_data.thread_id} is blocked on {'Facebook' if event_data.is_facebook_blocked else 'Messenger'} by {event_data.user_id}"
+        )
 
     async def on_friend_request_change(self, event_data: FriendRequestState):
         """Called when a friend request is confirmed/rejected or a friend request is sent by the Client.
 
-        Args: 
+        Args:
             event_data (FriendRequestState): Receives a ``FriendRequestState`` object.
         """
-        self.logger.info(f"User's ({event_data.user_id}) friend request has been {event_data.action}ed ")
-
+        self.logger.info(
+            f"User's ({event_data.user_id}) friend request has been {event_data.action}ed "
+        )
 
     async def on_poke_nofification(self, event_data: PokeNotification):
         """Called when a user pokes the Client.
@@ -469,4 +521,3 @@ class EventDispatcher:
             event_data (PokeNotification): Receives a ``PokeNotification`` object.
         """
         self.logger.info(f"{event_data.user_poked} poked Client.")
-

--- a/fbchat_muqit/manager.py
+++ b/fbchat_muqit/manager.py
@@ -1,0 +1,162 @@
+"""Multi-account orchestration and manager-scoped event routing."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections import defaultdict
+from typing import Awaitable, Callable, Dict, List, Optional, Tuple
+
+from .client import Client
+from .events.dispatcher import EventType
+from .exception.errors import FBChatError
+from .logging.logger import FBChatLogger, get_logger
+from .state import State
+from .storage import JsonSessionStorage, SessionStorage
+
+EventCallback = Callable[..., Awaitable[None]]
+
+__all__ = ["ClientManager"]
+
+
+class ClientManager:
+    """Run multiple :class:`~fbchat_muqit.client.Client` instances with isolated sessions."""
+
+    def __init__(
+        self,
+        *,
+        storage: Optional[SessionStorage] = None,
+        storage_dir: Optional[str] = None,
+    ) -> None:
+        self.clients: Dict[str, Client] = {}
+        if storage is not None:
+            self._storage: Optional[SessionStorage] = storage
+        elif storage_dir is not None:
+            self._storage = JsonSessionStorage(storage_dir)
+        else:
+            self._storage = None
+        self.logger: FBChatLogger = get_logger()
+        self._listeners: Dict[Tuple[str, EventType], List[EventCallback]] = defaultdict(
+            list
+        )
+        self._max_concurrent_handlers = 25
+        self._semaphore = asyncio.Semaphore(self._max_concurrent_handlers)
+
+    def event(self, *, client_id: str, event: Optional[EventType] = None):
+        """Register a handler for a specific account, e.g. ``@manager.event(client_id=\"acc1\")``."""
+
+        def decorator(func: EventCallback) -> EventCallback:
+            resolved: EventType
+            if event is None:
+                name = func.__name__
+                if not name.startswith("on_"):
+                    raise FBChatError(
+                        "Manager event handler must start with 'on_' or pass event=EventType explicitly"
+                    )
+                suffix = name[3:]
+                try:
+                    resolved = EventType(suffix.lower())
+                except ValueError as e:
+                    raise FBChatError(f"Unknown event type for handler {name}") from e
+            else:
+                resolved = event
+            self._listeners[(client_id, resolved)].append(func)
+            return func
+
+        return decorator
+
+    async def _route_manager_event(
+        self, client_id: str, event_name: EventType, *args
+    ) -> None:
+        for listener in self._listeners.get((client_id, event_name), []):
+            await self._safe_manager_listener(client_id, listener, event_name, *args)
+
+    async def _safe_manager_listener(
+        self, client_id: str, listener: EventCallback, event_name: EventType, *args
+    ) -> None:
+        async with self._semaphore:
+            try:
+                if inspect.iscoroutinefunction(listener):
+                    await listener(*args)
+                else:
+                    await asyncio.to_thread(listener, *args)
+            except Exception as e:
+                self.logger.error(
+                    f"Error in manager listener for client_id={client_id!r} event={event_name}: {e}",
+                    exc_info=True,
+                )
+
+    async def add_client(
+        self,
+        client_id: str,
+        cookies_path: str,
+        *,
+        user_agent: Optional[str] = None,
+        proxy: Optional[str] = None,
+        restore_from_storage: bool = False,
+        log_level: str = "INFO",
+        disable_logs: bool = False,
+        online: bool = True,
+    ) -> Client:
+        if client_id in self.clients:
+            raise FBChatError(f"Client id already registered: {client_id}")
+
+        initial_state: Optional[State] = None
+        if self._storage and restore_from_storage:
+            snap = await self._storage.load(client_id)
+            if snap and snap.get("cookies"):
+                initial_state = await State.from_cookie_list(
+                    snap["cookies"],
+                    user_agent=user_agent,
+                    proxy=proxy,
+                )
+
+        client = Client(
+            cookies_path,
+            userAgent=user_agent,
+            proxy=proxy,
+            log_level=log_level,
+            disable_logs=disable_logs,
+            online=online,
+            initial_state=initial_state,
+        )
+        client._manager_client_id = client_id  # type: ignore[attr-defined]
+        client._manager_route = self._route_manager_event  # type: ignore[attr-defined]
+        self.clients[client_id] = client
+        return client
+
+    async def remove_client(self, client_id: str, *, persist: bool = False) -> None:
+        client = self.clients.pop(client_id, None)
+        if client is None:
+            return
+        client._manager_route = None  # type: ignore[attr-defined]
+        client._manager_client_id = ""  # type: ignore[attr-defined]
+        if persist and self._storage is not None and client._state is not None:
+            await self._storage.save(client_id, client._state.dump_session_snapshot())
+        await client.stop_listening()
+        await client.close()
+
+    async def save_session(self, client_id: str) -> None:
+        if self._storage is None:
+            raise FBChatError("No session storage configured on ClientManager")
+        client = self.clients.get(client_id)
+        if client is None or client._state is None:
+            raise FBChatError(f"No active session for client id: {client_id}")
+        await self._storage.save(client_id, client._state.dump_session_snapshot())
+
+    async def broadcast(self, message: str, thread_id: str) -> None:
+        for cid, client in list(self.clients.items()):
+            try:
+                if client._state is not None:
+                    await client.send_message(message, thread_id)
+            except Exception as e:
+                self.logger.error(f"broadcast failed for {cid}: {e}", exc_info=True)
+
+    async def start_all(self) -> None:
+        for client in self.clients.values():
+            await client.start()
+            await client.start_listening()
+
+    async def stop_all(self) -> None:
+        for client in self.clients.values():
+            await client.stop_listening()

--- a/fbchat_muqit/models/deltas/parser.py
+++ b/fbchat_muqit/models/deltas/parser.py
@@ -1,11 +1,13 @@
 """
-This is the parser that parses all responses received from mqtt websocket. 
-We use `msgspec` module to parse the json bytes string directly to dataclasses instead of `dict`. And instead of `dataclass` we use `Struct` from `msgspec` module which is similar to dataclass but lighter. 
-But using msgspec makes code a bit messy as it is not as flexible as dataclass or attrs. 
+This is the parser that parses all responses received from mqtt websocket.
+We use `msgspec` module to parse the json bytes string directly to dataclasses instead of `dict`. And instead of `dataclass` we use `Struct` from `msgspec` module which is similar to dataclass but lighter.
+But using msgspec makes code a bit messy as it is not as flexible as dataclass or attrs.
 
-The responses received from `/ls_resp` topic are parsed separately because thoss are request specific. A response from `/ls_resp` topic is only received when we publish a payload request to `/ls_req` topic. 
+The responses received from `/ls_resp` topic are parsed separately because thoss are request specific. A response from `/ls_resp` topic is only received when we publish a payload request to `/ls_req` topic.
 """
+
 from __future__ import annotations
+import logging
 import time
 
 
@@ -17,77 +19,85 @@ from ...events.dispatcher import EventType
 from ...logging.logger import FBChatLogger, get_logger
 from ...exception.errors import FBChatError, ParsingError
 from ..attachment import (
-        Attachment,
-        AttachmentType,
-        PostAttachment,
-        SharedAttachment,
-        LocationAttachment,
-        ExternalAttachment,
-        ProfileAttachment,
-        ReelAttachment,
-        ProductAttachment,
-    )
+    Attachment,
+    AttachmentType,
+    PostAttachment,
+    SharedAttachment,
+    LocationAttachment,
+    ExternalAttachment,
+    ProfileAttachment,
+    ReelAttachment,
+    ProductAttachment,
+)
 from ..thread import getThreadType
 from .custom_type import (
-        GenieType, 
-        DecodedPayloadType, 
-        ReplyIdType, 
-        PayloadAttachmentType, 
-        MentionType, 
-        Value,
-        PostId
-    )
+    GenieType,
+    DecodedPayloadType,
+    ReplyIdType,
+    PayloadAttachmentType,
+    MentionType,
+    Value,
+    PostId,
+)
 from .attachments_deltas import (
-        extensibleattachment,
-        BlobAttachment,
-        StickerAttachment,
-        Mercury 
-        )
-from ..timestamps import (
-        MarkRead,
-        MarkUnread,
-        ReadReceipt,
-        DeliveryReceipt
-        )
+    extensibleattachment,
+    BlobAttachment,
+    StickerAttachment,
+    Mercury,
+)
+from ..timestamps import MarkRead, MarkUnread, ReadReceipt, DeliveryReceipt
 from .delta_wrapper import (
-        DeltaWrapper, 
-        Presence,
-        ClientPayload,
-        NewMessageDelta,
-        ClientPayloadDelta,
-        Typing,
-        FirstFetch,
-        )
+    DeltaWrapper,
+    Presence,
+    ClientPayload,
+    NewMessageDelta,
+    ClientPayloadDelta,
+    Typing,
+    FirstFetch,
+)
 from .group_deltas import (
-        AdminTextMessage,
-        AdminRemoved,
-        AdminAdded,
-        ApprovalMode,
-        ApprovalQueue,
-        ThreadAction,
-        ThreadDelete,
-        ThreadFolderMove,
-        ThreadMuteSettings,
-        ThreadName,
-        ThreadNickname,
-        ThreadEmoji,
-        ThreadMagicWord,
-        ThreadTheme,
-        ThreadMessageSharing,
-        ThreadMessagePin,
-        ThreadMessageUnPin,
-        ParticipantLeft,
-        ParticipantsAdded,
-        ApprovalQueue,
-        AllAdminText
-        )
+    AdminTextMessage,
+    AdminRemoved,
+    AdminAdded,
+    ApprovalMode,
+    ThreadAction,
+    ThreadDelete,
+    ThreadFolderMove,
+    ThreadMuteSettings,
+    ThreadName,
+    ThreadNickname,
+    ThreadEmoji,
+    ThreadMagicWord,
+    ThreadTheme,
+    ThreadMessageSharing,
+    ThreadMessagePin,
+    ThreadMessageUnPin,
+    ParticipantLeft,
+    ParticipantsAdded,
+    ApprovalQueue,
+    AllAdminText,
+)
 
-from .payloads import PayloadReplyMessage 
-from ..themes import ThemeData 
-from ..message import Mention, Message, MessageType, ThreadFolder, ThreadType, MessageType, MessageReaction, Reaction, Mention
-from ..notifications import FacebookNotifications, friendRequestList,PokeNotification, FriendRequestState
+from .payloads import PayloadReplyMessage
+from ..themes import ThemeData
+from ..message import (
+    Mention,
+    Message,
+    MessageType,
+    ThreadFolder,
+    ThreadType,
+    MessageReaction,
+    Reaction,
+)
+from ..notifications import (
+    FacebookNotifications,
+    friendRequestList,
+    PokeNotification,
+    FriendRequestState,
+)
 
 logger = get_logger()
+
 
 class ParsedEvent(Struct, frozen=True, eq=False):
     eventType: EventType
@@ -98,6 +108,7 @@ def measure_performance(func):
     """
     A decorator to measure the execution time of a function.
     """
+
     def wrapper(*args, **kwargs):
         start_time = time.perf_counter()
         result = func(*args, **kwargs)
@@ -105,6 +116,7 @@ def measure_performance(func):
         execution_time = end_time - start_time
         print(f"Function '{func.__name__}' executed in {execution_time:.6f} seconds.")
         return result
+
     return wrapper
 
 
@@ -115,8 +127,6 @@ def unwrap_to_str(obj: Any) -> str:
     return obj if isinstance(obj, str) else (str(obj) if obj is not None else "")
 
 
-
-
 def extract_lat_lon(uri: str) -> tuple[Optional[float], Optional[float]]:
     """Optimized lat/lon extraction with early returns"""
     try:
@@ -124,7 +134,7 @@ def extract_lat_lon(uri: str) -> tuple[Optional[float], Optional[float]]:
         marker_pos = uri.rfind("%7C")
         if marker_pos == -1:
             return None, None
-        coords_str = uri[marker_pos + 3:]
+        coords_str = uri[marker_pos + 3 :]
         # Find ampersand position
         amp_pos = coords_str.find("&")
         if amp_pos != -1:
@@ -139,21 +149,30 @@ def extract_lat_lon(uri: str) -> tuple[Optional[float], Optional[float]]:
         return None, None
 
 
-
 class MessageParser:
     def __init__(self, logger: FBChatLogger = get_logger()) -> None:
         self.logger: FBChatLogger = logger
-        
+
         self.decoder = json.Decoder()
-        self.delta_decoder = Decoder(type=DeltaWrapper, dec_hook=self.extract_value, strict=False)
-        self.mercury_decoder = Decoder(type=Mercury, dec_hook=self.extract_value, strict=False)
+        self.delta_decoder = Decoder(
+            type=DeltaWrapper, dec_hook=self.extract_value, strict=False
+        )
+        self.mercury_decoder = Decoder(
+            type=Mercury, dec_hook=self.extract_value, strict=False
+        )
         self.typing_decoder = Decoder(type=Typing, strict=False)
         self.presence_decoder = Decoder(type=Presence, strict=False)
         self.mention_decoder = Decoder(type=List[Mention], strict=False)
         self.fbnoti_decoder = Decoder(type=FacebookNotifications, strict=False)
-        self.thread_message_decoder = Decoder(type=List[VMessageThread], strict=False, dec_hook=self.extract_thread_id)
-        self.thread_message_atchmnt = Decoder(type=VMessageAttachment, strict=False, dec_hook=self.extract_value)
-        self.themes_decoder = Decoder(type=ThemeData, strict=False, dec_hook=self.extract_value)
+        self.thread_message_decoder = Decoder(
+            type=List[VMessageThread], strict=False, dec_hook=self.extract_thread_id
+        )
+        self.thread_message_atchmnt = Decoder(
+            type=VMessageAttachment, strict=False, dec_hook=self.extract_value
+        )
+        self.themes_decoder = Decoder(
+            type=ThemeData, strict=False, dec_hook=self.extract_value
+        )
 
         self.AdminTextArray: Set[str] = AllAdminText
         # Parser mapping
@@ -166,23 +185,23 @@ class MessageParser:
             AttachmentType.FACEBOOKPRODUCT: self.parse_product_extensible,
             "None": self.parse_story_extensible,
         }
-        # attachment type to message type 
+        # attachment type to message type
         self._attach_to_message = {
-                AttachmentType.IMAGE: MessageType.IMAGE,
-                AttachmentType.VIDEO: MessageType.VIDEO,
-                AttachmentType.GIF: MessageType.GIF,
-                AttachmentType.STICKER: MessageType.STICKER,
-                AttachmentType.FILE: MessageType.STICKER,
-                AttachmentType.AUDIO: MessageType.AUDIO,
-                AttachmentType.LOCATION: MessageType.LOCATION,
-                AttachmentType.FACEBOOKPOST: MessageType.FACEBOOK_POST,
-                AttachmentType.FACEBOOKREEL: MessageType.FACEBOOK_REEL,
-                AttachmentType.FACEBOOKPROFILE: MessageType.FACEBOOK_PROFILE,
-                AttachmentType.FACEBOOKGAME: MessageType.FACEBOOK_GAME,
-                AttachmentType.FACEBOOKPRODUCT: MessageType.FACEBOOK_PRODUCT,
-                AttachmentType.FACEBOOKSTORY: MessageType.FACEBOOK_STORY,
-                AttachmentType.EXTERNALURL: MessageType.EXTERNAL_URL
-                }
+            AttachmentType.IMAGE: MessageType.IMAGE,
+            AttachmentType.VIDEO: MessageType.VIDEO,
+            AttachmentType.GIF: MessageType.GIF,
+            AttachmentType.STICKER: MessageType.STICKER,
+            AttachmentType.FILE: MessageType.FILE,
+            AttachmentType.AUDIO: MessageType.AUDIO,
+            AttachmentType.LOCATION: MessageType.LOCATION,
+            AttachmentType.FACEBOOKPOST: MessageType.FACEBOOK_POST,
+            AttachmentType.FACEBOOKREEL: MessageType.FACEBOOK_REEL,
+            AttachmentType.FACEBOOKPROFILE: MessageType.FACEBOOK_PROFILE,
+            AttachmentType.FACEBOOKGAME: MessageType.FACEBOOK_GAME,
+            AttachmentType.FACEBOOKPRODUCT: MessageType.FACEBOOK_PRODUCT,
+            AttachmentType.FACEBOOKSTORY: MessageType.FACEBOOK_STORY,
+            AttachmentType.EXTERNALURL: MessageType.EXTERNAL_URL,
+        }
         # received payload type to evrnt type
         self.admin_text_to_event: Dict[str, EventType] = {
             "joinable_group_link_reset": EventType.THREAD_JOINABLE_LINK_RESET,
@@ -196,26 +215,23 @@ class MessageParser:
             "limit_sharing": EventType.THREAD_MESSAGE_SHARING_CHANGE,
             "instant_game_dynamic_custom_update": EventType.THREAD_GAME_CHANGE,
             "pin_messages_v2": EventType.MESSAGE_PINNED,
-            "unpin_messages_v2": EventType.MESSAGE_UNPINNED
-            }
+            "unpin_messages_v2": EventType.MESSAGE_UNPINNED,
+        }
         # mapping event type to msgspec Decoder
         # to decode received nested json payload
         self.get_decoder: Dict[EventType, Decoder] = {
-        EventType.ADMIN_ADDED: Decoder(type=AdminAdded),
-        EventType.MESSAGE_PINNED: Decoder(type=ThreadMessagePin),
-        EventType.THREAD_MESSAGE_SHARING_CHANGE: Decoder(type=ThreadMessageSharing),
-        EventType.THREAD_MAGIC_WORDS_CHANGE: Decoder(type=ThreadMagicWord),
-        EventType.THREAD_NICKNAME_CHANGE: Decoder(type=ThreadNickname),
-        EventType.THREAD_THEME_CHANGE: Decoder(type=ThreadTheme),
-        EventType.THREAD_EMOJI_CHANGE: Decoder(type=ThreadEmoji),
-        EventType.ADMIN_ADDED: Decoder(type=AdminAdded),
-        EventType.MESSAGE_PINNED: Decoder(type=ThreadMessagePin),
-        EventType.MESSAGE_UNPINNED: Decoder(type=ThreadMessageUnPin)
+            EventType.ADMIN_ADDED: Decoder(type=AdminAdded),
+            EventType.MESSAGE_PINNED: Decoder(type=ThreadMessagePin),
+            EventType.THREAD_MESSAGE_SHARING_CHANGE: Decoder(type=ThreadMessageSharing),
+            EventType.THREAD_MAGIC_WORDS_CHANGE: Decoder(type=ThreadMagicWord),
+            EventType.THREAD_NICKNAME_CHANGE: Decoder(type=ThreadNickname),
+            EventType.THREAD_THEME_CHANGE: Decoder(type=ThreadTheme),
+            EventType.THREAD_EMOJI_CHANGE: Decoder(type=ThreadEmoji),
+            EventType.ADMIN_ADDED: Decoder(type=AdminAdded),
+            EventType.MESSAGE_PINNED: Decoder(type=ThreadMessagePin),
+            EventType.MESSAGE_UNPINNED: Decoder(type=ThreadMessageUnPin),
         }
 
-
-
-    
     def extract_value(self, typ: Any, obj: Any):
         """Custom decoder hook for `msgspec`"""
         if typ is Value and isinstance(obj, (str, dict)):
@@ -225,130 +241,146 @@ class MessageParser:
             decoded_payload = self.decode_byte_payload(obj)
             if decoded_payload:
                 return DecodedPayloadType((decoded_payload,))
-            return DecodedPayloadType((obj,)) 
+            return DecodedPayloadType((obj,))
 
         elif typ is ReplyIdType and isinstance(obj, dict):
             return ReplyIdType(obj["dataToMessageId"]["id"])
 
         elif typ is GenieType and isinstance(obj, dict):
-            return GenieType(obj["genie_message"]["__typename"]) if obj["genie_message"] else GenieType(None)
+            return (
+                GenieType(obj["genie_message"]["__typename"])
+                if obj["genie_message"]
+                else GenieType(None)
+            )
 
         elif typ is MentionType and isinstance(obj, dict):
-            if "prng" in obj:        
+            if "prng" in obj:
                 return MentionType(self.mention_decoder.decode(obj["prng"]))
             return MentionType()
 
         elif typ is PayloadAttachmentType:
             if isinstance(obj, str):
-                return PayloadAttachmentType(
-                    (self.mercury_decoder.decode(obj),)
-                    )
+                return PayloadAttachmentType((self.mercury_decoder.decode(obj),))
         elif typ is PostId:
             return PostId(obj["id"]) if "id" in obj else PostId("")
         return obj
 
-    def decode_byte_payload(self, byte_array: List[int])->Optional[ClientPayloadDelta]:
+    def decode_byte_payload(
+        self, byte_array: List[int]
+    ) -> Optional[ClientPayloadDelta]:
         """Decode byte array payload to JSON"""
         b_array = bytes(byte_array)
         try:
-            return json.decode(b_array, type=ClientPayloadDelta, dec_hook=self.extract_value, strict=False)
+            return json.decode(
+                b_array,
+                type=ClientPayloadDelta,
+                dec_hook=self.extract_value,
+                strict=False,
+            )
         except Exception as e:
-            self.logger.debug(f"Failed to decode bytes payload array, payload type: {type(byte_array)} errror: {e} payload: {b_array[:100] if len(b_array) > 100 else b_array}")
+            self.logger.debug(
+                f"Failed to decode bytes payload array, payload type: {type(byte_array)} errror: {e} payload: {b_array[:100] if len(b_array) > 100 else b_array}"
+            )
             raise ParsingError(f"Failed to decode bytes array error: {e}")
 
+    # ExtensibleAttachments are a bit complex
 
-
-    # ExtensibleAttachments are a bit complex 
-
-    def parse_post_extensible(self, data)-> PostAttachment:
-        story = data.story_attachment    
+    def parse_post_extensible(self, data) -> PostAttachment:
+        story = data.story_attachment
         post = story.target
         return PostAttachment(
             id=data.legacy_attachment_id,
             title=story.title,
             description=story.description or "",
-            post_preview=story.media, #type: ignore
+            post_preview=story.media,  # type: ignore
             post_url=story.url or "",
             post=post,
-            source=story.source
-            )
+            source=story.source,
+        )
 
-    def parse_story_extensible(self, data: extensibleattachment)->SharedAttachment:
+    def parse_story_extensible(self, data: extensibleattachment) -> SharedAttachment:
         return SharedAttachment(
-                id=data.legacy_attachment_id,
-                title=str(data.story_attachment.title),
-                description=str(data.story_attachment.description) if data.story_attachment.media else None,
-                media=data.story_attachment.media
-                )
+            id=data.legacy_attachment_id,
+            title=str(data.story_attachment.title),
+            description=(
+                str(data.story_attachment.description)
+                if data.story_attachment.media
+                else None
+            ),
+            media=data.story_attachment.media,
+        )
 
-
-    def parse_reel_extensible(self, data: extensibleattachment)->ReelAttachment:
+    def parse_reel_extensible(self, data: extensibleattachment) -> ReelAttachment:
         story = data.story_attachment
         return ReelAttachment(
             id=data.legacy_attachment_id,
             url=story.url or "",
-            media=story.media, #type: ignore
+            media=story.media,  # type: ignore
             source=story.source or "",
-            video_id=story.target.video_id, #type: ignore
+            video_id=story.target.video_id,  # type: ignore
             title=story.title,
-            description=story.description or ""
-            )
+            description=story.description or "",
+        )
 
-
-    def parse_profile_extensible(self, data)->ProfileAttachment:
+    def parse_profile_extensible(self, data) -> ProfileAttachment:
         return ProfileAttachment(
             id=data.legacy_attachment_id,
             profile_id=data.story_attachment.target.id,
             profile_name=data.story_attachment.target.name,
             profile_url=data.story_attachment.url or "",
             profile_picture=data.story_attachment.target.picture,
-            cover_photo=data.story_attachment.target.cover_photo["photo"]["image"]["uri"] if "photo" in data.story_attachment.target.cover_photo else None
-            )
+            cover_photo=(
+                data.story_attachment.target.cover_photo["photo"]["image"]["uri"]
+                if "photo" in data.story_attachment.target.cover_photo
+                else None
+            ),
+        )
 
-
-    def parse_external_extensible(self, data: extensibleattachment)->ExternalAttachment:
+    def parse_external_extensible(
+        self, data: extensibleattachment
+    ) -> ExternalAttachment:
         story = data.story_attachment
         return ExternalAttachment(
             id=data.legacy_attachment_id,
             url=story.url or "",
             media=story.media,
             title=story.title,
-            description=story.description
-            )
+            description=story.description,
+        )
 
-
-    def parse_location_extensible(self, data: extensibleattachment) -> LocationAttachment:
+    def parse_location_extensible(
+        self, data: extensibleattachment
+    ) -> LocationAttachment:
         """Parse location sharing ExtensibleAttachment"""
         story = data.story_attachment
-        lat, long = extract_lat_lon(story.media.preview.url) #type: ignore
+        lat, long = extract_lat_lon(story.media.preview.url)  # type: ignore
         return LocationAttachment(
             id=data.legacy_attachment_id,
             url=story.url or "",
-            media=story.media, #type: ignore
+            media=story.media,  # type: ignore
             address=story.description,
             latitude=lat,  # Would need to parse from map URL if needed
             longitude=long,
-            is_live=False
+            is_live=False,
         )
 
-    def parse_product_extensible(self, data: extensibleattachment)-> ProductAttachment:
+    def parse_product_extensible(self, data: extensibleattachment) -> ProductAttachment:
         return ProductAttachment(
             id=data.legacy_attachment_id,
             product_name=data.story_attachment.title,
             product_price=str(data.story_attachment.description) or "",
-            url=str(data.story_attachment.url) or ""
-            )
-    
+            url=str(data.story_attachment.url) or "",
+        )
 
     def parse_attachment(self, mercury) -> Optional[Attachment]:
 
         # Direct returns for simple cases
         if mercury.sticker_attachment:
             return mercury.sticker_attachment
-        
+
         elif mercury.blob_attachment:
             return mercury.blob_attachment
-            
+
         elif mercury.extensible_attachment:
             # get parser by extensible attachment's genie type
             parser = self._parsers.get(mercury.extensible_attachment.genie_attachment)
@@ -356,26 +388,33 @@ class MessageParser:
                 return parser(mercury.extensible_attachment)
         return None
 
-   
-   
-    def parse_t_ms(self, payload)-> Generator[Optional[ParsedEvent]]:
-        self.logger.debug(self.decoder.decode(payload))
+    def parse_t_ms(self, payload) -> Generator[Optional[ParsedEvent]]:
         decoded_delta = self.delta_decoder.decode(payload)
         return (self.parse_deltas(d) for d in decoded_delta.deltas)
 
-    only_decode_notification = (b"live_poke", b"friending_state_change", b"jewel_requests_remove_old", b"mobile_requests_count")
+    only_decode_notification = (
+        b"live_poke",
+        b"friending_state_change",
+        b"jewel_requests_remove_old",
+        b"mobile_requests_count",
+    )
 
-    def parse_all(self, topic, payload)-> Optional[ParsedEvent]:
-        self.logger.debug(f"Parsing {topic}: {json.decode(payload)}")
-        if (topic == '/thread_typing' and b'"type":"typ"' in payload) or topic == "/orca_typing_notifications":
+    def parse_all(self, topic, payload) -> Optional[ParsedEvent]:
+        if self.logger.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug("Parsing topic %s (%d bytes)", topic, len(payload))
+        if (
+            topic == "/thread_typing" and b'"type":"typ"' in payload
+        ) or topic == "/orca_typing_notifications":
             eventdata = self.typing_decoder.decode(payload)
             return ParsedEvent(EventType.TYPING, (eventdata,))
 
-        elif topic == '/orca_presence' and b'"list_type"' in payload:
+        elif topic == "/orca_presence" and b'"list_type"' in payload:
             eventdata = self.presence_decoder.decode(payload)
             return ParsedEvent(EventType.PRESENCE, (eventdata,))
 
-        elif topic == '/legacy_web' and filter(lambda x: x in payload, self.only_decode_notification):
+        elif topic == "/legacy_web" and filter(
+            lambda x: x in payload, self.only_decode_notification
+        ):
 
             eventdata = self.fbnoti_decoder.decode(payload)
             return self.parse_notifications(eventdata)
@@ -385,25 +424,47 @@ class MessageParser:
             return None
 
         else:
-            self.logger.debug(f"Unknown payload delta from Topic: '{topic}' received: {self.decoder.decode(payload)}")
+            if self.logger.logger.isEnabledFor(logging.DEBUG):
+                self.logger.debug(
+                    "Unknown payload delta from topic %r (%d bytes)",
+                    topic,
+                    len(payload),
+                )
             return None
 
-
-    def parse_message(self, data, replied_to_message = None)-> Message:
+    def parse_message(self, data, replied_to_message=None) -> Message:
         """
         data (NewMessageDelta | PayloadReplyMessage): NewMessageDelta received when It is a normal message and if the message was reply to another message PayloadReplyMessage is received and `replied to` mesaage data is provided to replied_to_message
         replied_to_message (Message): A `Message` object containing replied to message data.
         """
-        attachments = None 
+        attachments = None
         if isinstance(data, NewMessageDelta) and data.attachments:
             attachments = [self.parse_attachment(a.mercury) for a in data.attachments]
 
         elif isinstance(data, PayloadReplyMessage) and data.attachments:
-            attachments = [self.parse_attachment(a.mercuryJSON[0]) for a in data.attachments]
-        message_type = MessageType.TEXT
-        if attachments:
-            message_type = self._attach_to_message[attachments[0].type] if attachments[0] else MessageType.TEXT
+            attachments = [
+                self.parse_attachment(a.mercuryJSON[0]) for a in data.attachments
+            ]
 
+        message_type = MessageType.TEXT
+        first_attachment = next((a for a in (attachments or []) if a is not None), None)
+        if first_attachment is not None:
+            message_type = self._attach_to_message.get(
+                first_attachment.type, MessageType.TEXT
+            )
+
+        thread_folder = ThreadFolder.INBOX
+        folder_raw = getattr(data.messageMetadata, "folder", None)
+        if folder_raw is not None:
+            try:
+                thread_folder = ThreadFolder(str(folder_raw))
+            except (ValueError, TypeError):
+                thread_folder = ThreadFolder.INBOX
+
+        participants_count = (
+            len(data.participants) if getattr(data, "participants", None) else 0
+        )
+        thread_type = ThreadType.GROUP if participants_count >= 3 else ThreadType.USER
 
         return Message(
             id=data.messageMetadata.id,
@@ -413,96 +474,125 @@ class MessageParser:
             reaction=[],
             mentions=data.mentions,
             thread_id=data.messageMetadata.thread_id,
-            thread_type=ThreadType.GROUP,
-            thread_folder=ThreadFolder.INBOX,
+            thread_type=thread_type,
+            thread_folder=thread_folder,
             thread_participants=data.participants,
             attachments=attachments,
             timestamp=int(data.messageMetadata.timestamp),
-            can_unsend=True if data.messageMetadata.unsendType == "Can_Unsend" else False,
+            can_unsend=(
+                True if data.messageMetadata.unsendType == "Can_Unsend" else False
+            ),
             unsent=False,
-            replied_to_message=replied_to_message
-            )
+            replied_to_message=replied_to_message,
+        )
 
-
-    def extract_thread_id(self, typ, obj)-> str:
+    def extract_thread_id(self, typ, obj) -> str:
         return Value(obj["thread_fbid"]) or Value(obj["other_user_id"])
 
-
-    def parse_thread_message(self, payload: dict[str, Any])-> List[Message]:
+    def parse_thread_message(self, payload: dict[str, Any]) -> List[Message]:
         """Parse meessages from fetched graphql Thread Messages"""
         thread_message = self.thread_message_decoder.decode(json.encode(payload))[0]
         thread_id = str(thread_message.message_thread.thread_key)
         thread_type = getThreadType[thread_message.message_thread.thread_type]
-        nodes: List[Dict[str, Any]] = thread_message.message_thread.messages.nodes 
+        nodes: List[Dict[str, Any]] = thread_message.message_thread.messages.nodes
 
-        messages = [self.parse_message_from_graphql(m, thread_id, thread_type) for m in nodes]
+        messages = [
+            self.parse_message_from_graphql(m, thread_id, thread_type) for m in nodes
+        ]
         return messages
 
-    def parse_message_from_graphql(self, m: dict[str, Any], thread_id: str, thread_type = ThreadType.UNKNOWN)-> Message:
+    def parse_message_from_graphql(
+        self, m: dict[str, Any], thread_id: str, thread_type=ThreadType.UNKNOWN
+    ) -> Message:
         """Parse a single fetched grapql message"""
         try:
-            return  Message(
-                id=m["message_id"], 
+            return Message(
+                id=m["message_id"],
                 text=m["message"]["text"],
                 sender_id=m["message_sender"]["id"],
                 thread_id=thread_id,
                 thread_type=thread_type,
                 message_type=self.get_from_attachment(m),
                 timestamp=m["timestamp_precise"],
-                can_unsend=True if m.get("message_unsendability_status") == "can_unsend" else False, 
+                can_unsend=(
+                    True
+                    if m.get("message_unsendability_status") == "can_unsend"
+                    else False
+                ),
                 unsent=True if m["unsent_timestamp_precise"] == "0" else False,
                 reaction=[
                     MessageReaction(
-                        id="", 
+                        id="",
                         reaction=r["reaction"],
                         reactor=r["user"]["id"],
                         thread_id=Value(thread_id),
                         reaction_type=Reaction.ADDED,
                         reacted_message_sender=m["message_sender"]["id"],
                         timestamp=None,
-                    )   
+                    )
                     for r in m["message_reactions"]
                 ],
                 mentions=self.parse_mention(m["message"]["ranges"]),
                 thread_folder=ThreadFolder.INBOX,
                 thread_participants=None,
-                attachments=[self.parse_attachment(self.thread_message_atchmnt.decode(json.encode(m)))] if self.has_attachment(m) else None,
-                
-                )
+                attachments=(
+                    [
+                        self.parse_attachment(
+                            self.thread_message_atchmnt.decode(json.encode(m))
+                        )
+                    ]
+                    if self.has_attachment(m)
+                    else None
+                ),
+            )
         except KeyError as e:
-            raise ParsingError(f"Couldn't get {e.args[0]} data from message with Id ({m['message_id']})")
+            raise ParsingError(
+                f"Couldn't get {e.args[0]} data from message with Id ({m['message_id']})"
+            )
         except Exception as e:
-            raise FBChatError(f"Failed to parse message with Id: {m['message_id']}.", original_exception=e)
+            raise FBChatError(
+                f"Failed to parse message with Id: {m['message_id']}.",
+                original_exception=e,
+            )
 
-    def get_from_attachment(self, m)->MessageType:
-        
+    def get_from_attachment(self, m) -> MessageType:
+
         if m["blob_attachments"] != []:
-            return self._attach_to_message[AttachmentType(m["blob_attachments"][0]["__typename"])]
+            return self._attach_to_message[
+                AttachmentType(m["blob_attachments"][0]["__typename"])
+            ]
         elif m["sticker"]:
             return MessageType.STICKER
         elif m["extensible_attachment"]:
-            return self._attach_to_message[AttachmentType(m["extensible_attachment"]["story_attachment"]["target"]["__typename"])] if m["extensible_attachment"]["story_attachment"]["target"] else MessageType.TEXT
+            return (
+                self._attach_to_message[
+                    AttachmentType(
+                        m["extensible_attachment"]["story_attachment"]["target"][
+                            "__typename"
+                        ]
+                    )
+                ]
+                if m["extensible_attachment"]["story_attachment"]["target"]
+                else MessageType.TEXT
+            )
         else:
             return MessageType.TEXT
 
-    def parse_mention(self, ranges)->List[Mention] | None:
+    def parse_mention(self, ranges) -> List[Mention] | None:
         if ranges != []:
             return [
-                    Mention(
-                        user_id=m["entity"]["id"],
-                        offset=m["offset"],
-                        length=m["length"]
-                        )
-                    for m in ranges
-                    ]
+                Mention(
+                    user_id=m["entity"]["id"], offset=m["offset"], length=m["length"]
+                )
+                for m in ranges
+            ]
 
     def has_attachment(self, m):
         return m["blob_attachments"] or m["sticker"] or (m["blob_attachments"] != [])
 
-
     def parse_notifications(self, eventdata):
 
-        if isinstance(eventdata,friendRequestList):
+        if isinstance(eventdata, friendRequestList):
             return ParsedEvent(EventType.FRIEND_REQUEST_LIST_UPDATE, (eventdata,))
         elif isinstance(eventdata, FriendRequestState):
             return ParsedEvent(EventType.FRIEND_REQUEST_CHANGE, (eventdata,))
@@ -510,39 +600,51 @@ class MessageParser:
         elif isinstance(eventdata, PokeNotification):
             return ParsedEvent(EventType.POKE_NOTIFICATION, (eventdata,))
 
-    def parse_deltas(self, deltas)-> Optional[ParsedEvent]:
+    def parse_deltas(self, deltas) -> Optional[ParsedEvent]:
 
         try:
-    
+
             if isinstance(deltas, NewMessageDelta):
                 return ParsedEvent(EventType.MESSAGE, (self.parse_message(deltas),))
 
             elif isinstance(deltas, ClientPayload):
                 data: ClientPayloadDelta = deltas.payload[0]
-            # Theme update also sometime updates  quick reaction and magic words
+                # Theme update also sometime updates  quick reaction and magic words
                 if data.deltas[0].messageReply:
                     etype: EventType = EventType.MESSAGE
                     if data.deltas[0].replyType == 1:
                         etype = EventType.MESSAGE_BUMP
-                    replied_to_message =  self.parse_message(data.deltas[0].messageReply.repliedToMessage)
-                    main_message = self.parse_message(data.deltas[0].messageReply.message, replied_to_message)
+                    replied_to_message = self.parse_message(
+                        data.deltas[0].messageReply.repliedToMessage
+                    )
+                    main_message = self.parse_message(
+                        data.deltas[0].messageReply.message, replied_to_message
+                    )
                     return ParsedEvent(etype, (main_message,))
- 
+
                 if data.deltas[0].messageReaction:
-                    return ParsedEvent(EventType.MESSAGE_REACTION, (data.deltas[0].messageReaction,))
+                    return ParsedEvent(
+                        EventType.MESSAGE_REACTION, (data.deltas[0].messageReaction,)
+                    )
 
                 elif data.deltas[0].messageUnsend:
-                    return ParsedEvent(EventType.MESSAGE_UNSENT, (data.deltas[0].messageUnsend,))
+                    return ParsedEvent(
+                        EventType.MESSAGE_UNSENT, (data.deltas[0].messageUnsend,)
+                    )
 
-                elif  data.deltas[0].messageRemove:
-                    return ParsedEvent(EventType.MESSAGE_REMOVE, (data.deltas[0].messageRemove,))
+                elif data.deltas[0].messageRemove:
+                    return ParsedEvent(
+                        EventType.MESSAGE_REMOVE, (data.deltas[0].messageRemove,)
+                    )
 
                 elif data.deltas[0].muteThread:
-                    return ParsedEvent(EventType.THREAD_MUTE, (data.deltas[0].muteThread,))
+                    return ParsedEvent(
+                        EventType.THREAD_MUTE, (data.deltas[0].muteThread,)
+                    )
                 elif data.deltas[0].pageNotification:
-                    return ParsedEvent(EventType.PAGE_NOTIFICATION, (data.deltas[0].pageNotification,))
-            
-
+                    return ParsedEvent(
+                        EventType.PAGE_NOTIFICATION, (data.deltas[0].pageNotification,)
+                    )
 
             elif isinstance(deltas, AdminRemoved):
                 return ParsedEvent(EventType.ADMIN_REMOVED, (deltas,))
@@ -585,37 +687,42 @@ class MessageParser:
                 return ParsedEvent(EventType.THREAD_MUTE_SETTINGS, (deltas,))
 
             elif isinstance(deltas, AdminTextMessage):
-                if b'remove_admin' in bytes(deltas.untypedData) or deltas.type not in self.AdminTextArray:
+                if (
+                    b"remove_admin" in bytes(deltas.untypedData)
+                    or deltas.type not in self.AdminTextArray
+                ):
                     return None
                 evenType = self.admin_text_to_event[deltas.type]
                 decodedData = self.get_decoder[evenType].decode(deltas.untypedData)
                 return ParsedEvent(evenType, (decodedData, deltas.messageMetadata))
 
         except Exception as e:
-            raise ParsingError(f"Failed to parse and dispatch delta: {deltas}", original_exception=e)
+            raise ParsingError(
+                f"Failed to parse and dispatch delta: {deltas}", original_exception=e
+            )
 
 
-
-
-
-# below class used to parse fetched responses for thread messages 
+# below class used to parse fetched responses for thread messages
 # usually used when you call fetch_thread_messages() from MessengerClinet class
 class VNodes(Struct, frozen=True, eq=False):
     nodes: List
 
+
 class VThreadMessages(Struct, frozen=True, eq=False):
-    messages: VNodes 
+    messages: VNodes
     thread_key: Value
     thread_type: str
+
+
 class VMessageThread(Struct, frozen=True, eq=False):
     message_thread: VThreadMessages
 
-class VMessageAttachment(Struct, frozen=True, eq=False): 
+
+class VMessageAttachment(Struct, frozen=True, eq=False):
     extensible_attachment: Optional[extensibleattachment] = None
-    sticker_attachment: Optional[StickerAttachment] = field(name="sticker", default=None)
-    blob_attachment: Optional[List[BlobAttachment]] = field(name="blob_attachments", default=None)
-
-
-
-
-
+    sticker_attachment: Optional[StickerAttachment] = field(
+        name="sticker", default=None
+    )
+    blob_attachment: Optional[List[BlobAttachment]] = field(
+        name="blob_attachments", default=None
+    )

--- a/fbchat_muqit/muqit.py
+++ b/fbchat_muqit/muqit.py
@@ -1,9 +1,11 @@
-""" Facebook Messenger uses Mqtt protocol to send and receive messages. This File handles Mqtt broker. """
+"""Facebook Messenger uses Mqtt protocol to send and receive messages. This File handles Mqtt broker."""
 
 from __future__ import annotations
 
 
-import aiomqtt, asyncio, aiohttp
+import aiomqtt
+import asyncio
+import aiohttp
 import random
 import json
 import time
@@ -15,7 +17,7 @@ from typing import Any, Callable, Dict, Optional
 from yarl import URL
 
 
-from .exception.errors import *
+from .exception.errors import FBChatError
 
 from .graphql import from_doc_id
 from .state import State
@@ -24,12 +26,15 @@ from .utils.utils import generate_uuid
 
 logger = get_logger()
 
-def generate_session_id()-> int:
-    return random.randint(1, 2 ** 53)
+
+def generate_session_id() -> int:
+    return random.randint(1, 2**53)
 
 
 def get_cookie_header(session: aiohttp.ClientSession, url: str) -> str:
-    return session.cookie_jar.filter_cookies(URL(url)).output(header="", sep=";").lstrip()
+    return (
+        session.cookie_jar.filter_cookies(URL(url)).output(header="", sep=";").lstrip()
+    )
 
 
 def get_random_reconnect_time() -> int:
@@ -62,26 +67,25 @@ class Mqtt:
 
     _message_handler: Optional[Callable] = field(default=None)
 
-    HOST = "edge-chat.facebook.com" # Mqtt host for facebook
-    iris_re   = re.compile(rb'"irisSeqId":\s*"(\d+)"')
-    first_re  = re.compile(rb'"firstDeltaSeqId":\s*(\d+)')
-    last_re   = re.compile(rb'"lastIssuedSeqId":\s*(\d+)')
-    tq_re     = re.compile(rb'"tqSeqId":\s*"(\d+)"')
-    sync_re   = re.compile(rb'"syncToken":\s*"([^"]+)"')
+    HOST = "edge-chat.facebook.com"  # Mqtt host for facebook
+    iris_re = re.compile(rb'"irisSeqId":\s*"(\d+)"')
+    first_re = re.compile(rb'"firstDeltaSeqId":\s*(\d+)')
+    last_re = re.compile(rb'"lastIssuedSeqId":\s*(\d+)')
+    tq_re = re.compile(rb'"tqSeqId":\s*"(\d+)"')
+    sync_re = re.compile(rb'"syncToken":\s*"([^"]+)"')
 
-    
     @classmethod
     async def connect(
-            cls, 
-            state: State, 
-            chat_on: bool, 
-            foreground: bool,
-            message_handler: Callable,
-            update_presence: bool = True,
-            auto_reconnect: bool = True
-            )-> Mqtt:
+        cls,
+        state: State,
+        chat_on: bool,
+        foreground: bool,
+        message_handler: Callable,
+        update_presence: bool = True,
+        auto_reconnect: bool = True,
+    ) -> Mqtt:
 
-        # configuring mqtt client 
+        # configuring mqtt client
         mqttClint = aiomqtt.Client(
             hostname=cls.HOST,
             identifier="mqttwsclient",
@@ -89,11 +93,11 @@ class Mqtt:
             protocol=aiomqtt.ProtocolVersion.V31,
             transport="websockets",
             port=443,
-            keepalive=60
+            keepalive=60,
         )
 
         sequence_id = await cls._fetch_sequence_id(state)
-        
+
         # creating `Mqtt` class instance for handlling mqtt connections
         self = cls(
             _state=state,
@@ -103,12 +107,12 @@ class Mqtt:
             _sequence_id=sequence_id,
             _mqttClientID=state._mqttClientID,
             _mqttAppID=state._mqttAppID,
-            _region=state._region,  
+            _region=state._region,
             _message_handler=message_handler,
             _update_presence=update_presence,
-            _auto_reconnect=auto_reconnect
+            _auto_reconnect=auto_reconnect,
         )
-    
+
         self._mqttClient._client.tls_set()
         self._configure_mqtt_options()
 
@@ -130,9 +134,8 @@ class Mqtt:
 
         return self
 
-
     @staticmethod
-    async def _fetch_sequence_id(state)-> int:
+    async def _fetch_sequence_id(state) -> int:
         """Fetch sequence ID."""
         params = {
             "limit": 1,
@@ -140,37 +143,36 @@ class Mqtt:
             "before": None,
             "includeDeliveryReceipts": False,
             "includeSeqID": True,
-            }
+        }
         j = await state._graphql_requests(from_doc_id("1349387578499440", params))
-        sequence_id = j[0]["viewer"]["message_threads"]["sync_sequence_id"] #type: ignore
+        sequence_id = j[0]["viewer"]["message_threads"]["sync_sequence_id"]  # type: ignore
         logger.debug(f"fetched sequence id: {sequence_id}")
         return int(sequence_id)
 
-
-    def _configure_mqtt_options(self)-> None:
+    def _configure_mqtt_options(self) -> None:
         session_id = generate_session_id()
         region = self._region
         mqttClientID = self._mqttClientID
         mqttAppID = self._mqttAppID
 
-        # The topics fbchat-muqit will listen to 
+        # The topics fbchat-muqit will listen to
         # with open("./fbchat_muqit/topics.json", "r") as f:
         #     data = json.loads(f.read())
         # topics = [i for i in data]
         # print(*topics)
         topics = [
             "/legacy_web",  # web related messages during graphql requests
-            "/ls_req",    # used to publish message payloads
-            "/ls_resp",   # receives response after pub to /ls_req
-            "/t_ms",      # all kinds of message, message events received
+            "/ls_req",  # used to publish message payloads
+            "/ls_resp",  # receives response after pub to /ls_req
+            "/t_ms",  # all kinds of message, message events received
             "/rtc_multi",
-            #"/t_rtc_multi",  # receives group calls
-            "/thread_typing", # typing status update received
+            # "/t_rtc_multi",  # receives group calls
+            "/thread_typing",  # typing status update received
             "/orca_typing_notifications",  # Messenger notifi.
-            "/orca_presence",     # receives users presence updates
+            "/orca_presence",  # receives users presence updates
             "/br_sr",
-            "/friend_request",      # receives friend request notification
-            "/friending_state_change", # when friend request confirmed/removed
+            "/friend_request",  # receives friend request notification
+            "/friending_state_change",  # when friend request confirmed/removed
             "/friend_requests_seen",  # new friend request seen
             "/sr_res",
             "/webrtc",
@@ -202,7 +204,7 @@ class Mqtt:
             "pack": [],
             "p": None,
             "aids": None,
-            "a": self._state._userAgent
+            "a": self._state._userAgent,
         }
         self._mqttClient._client.username_pw_set(json.dumps(username))
 
@@ -212,15 +214,15 @@ class Mqtt:
             ),
             "User-Agent": self._state._userAgent,
             "Origin": "https://www.facebook.com",
-            "Host": self.HOST
+            "Host": self.HOST,
         }
 
         self._mqttClient._client.ws_set_options(
-            path=f"/chat?region={region}&sid={session_id}&cid={mqttClientID}", headers=headers
+            path=f"/chat?region={region}&sid={session_id}&cid={mqttClientID}",
+            headers=headers,
         )
 
-    
-    async def _messenger_queue_publish(self)-> None:
+    async def _messenger_queue_publish(self) -> None:
         # configure receiving messages.
         payload = {
             "sync_api_version": 10,
@@ -243,16 +245,22 @@ class Mqtt:
     def extract_meta(self, raw):
         """extracts sequence and sync token"""
         ids = {
-            "firstDeltaSeqId": int(m.group(1)) if (m := self.first_re.search(raw)) else None,
-            "lastIssuedSeqId": int(m.group(1)) if (m := self.last_re.search(raw)) else None,
-            "syncToken": m.group(1).decode() if (m := self.sync_re.search(raw)) else None,
+            "firstDeltaSeqId": (
+                int(m.group(1)) if (m := self.first_re.search(raw)) else None
+            ),
+            "lastIssuedSeqId": (
+                int(m.group(1)) if (m := self.last_re.search(raw)) else None
+            ),
+            "syncToken": (
+                m.group(1).decode() if (m := self.sync_re.search(raw)) else None
+            ),
         }
-        self._sequence_id = ids["lastIssuedSeqId"] or ids["firstDeltaSeqId"] or self._sequence_id 
+        self._sequence_id = (
+            ids["lastIssuedSeqId"] or ids["firstDeltaSeqId"] or self._sequence_id
+        )
         self._sync_token = ids["syncToken"] or self._sync_token
         if not any(ids.values()):
             logger.debug("No seqId/syncToken found in payload slice")
-
-    
 
     async def listen(self):
         if not self._mqttClient:
@@ -262,17 +270,23 @@ class Mqtt:
             async for message in self._mqttClient.messages:
                 if not self._running and not self._reconnecting:
                     break
-                try:    
-                    if b'lastIssuedSeqId' in message.payload or b'firstDeltaSeqId' in message.payload or b'syncToken' in message.payload: #type: ignore
+                try:
+                    if b"lastIssuedSeqId" in message.payload or b"firstDeltaSeqId" in message.payload or b"syncToken" in message.payload:  # type: ignore
                         self.extract_meta(message.payload)
 
-
-                    payload = message.payload #type: ignore
+                    payload = message.payload  # type: ignore
                     topic = message.topic.value
                     if self._message_handler:
                         await self._message_handler(topic, payload)
+                except asyncio.CancelledError:
+                    raise
                 except Exception as e:
-                    FBChatError("Failed to receive message payloads", original_exception=e)
+                    logger.error(
+                        "Failed to process MQTT message payload", exc_info=True
+                    )
+                    raise FBChatError(
+                        "Failed to receive message payloads", original_exception=e
+                    ) from e
 
         except asyncio.CancelledError:
             # normal shutdown, just exit silently
@@ -286,7 +300,6 @@ class Mqtt:
         finally:
             logger.info("MQTT listening loop ended")
 
-
     def parse_json(self, data):
         try:
             return json.loads(data)
@@ -297,12 +310,10 @@ class Mqtt:
             logger.error(f"Unexpected error parsing JSON: {e}")
             return {"error": str(e), "raw_data": data}
 
-
     async def set_foreground(self, value):
         payload = json.dumps({"foreground": value})
         await self._mqttClient.publish("/foreground_state", payload=payload, qos=1)
         self._foreground = value
-
 
     async def set_chat_on(self, value):
         data = {"make_user_available_when_in_foreground": value}
@@ -310,15 +321,13 @@ class Mqtt:
         await self._mqttClient.publish("/set_client_settings", payload=payload, qos=1)
         self._chat_on = value
 
-
     def _generate_presence(self) -> Dict[str, Any]:
         """Generate presence payload"""
         return {
             "user_id": self._state.user_id,
             "last_active": int(time.time() * 1000),
-            "active": True
+            "active": True,
         }
-
 
     async def _presence_updater(self):
         """Periodically update presence status"""
@@ -327,9 +336,7 @@ class Mqtt:
                 if self._mqttClient._client.is_connected():
                     presence_payload = self._generate_presence()
                     await self._mqttClient.publish(
-                        '/orca_presence', 
-                        json.dumps({"p": presence_payload}), 
-                        qos=1
+                        "/orca_presence", json.dumps({"p": presence_payload}), qos=1
                     )
                     logger.debug("Presence updated")
                 await asyncio.sleep(50)  # Update every 50 seconds
@@ -341,8 +348,6 @@ class Mqtt:
                 logger.error(f"Error updating presence: {e}")
                 await asyncio.sleep(10)
 
-
-    
     async def _cancel_task(self, task: asyncio.Task | None):
         """Cancel an asyncio task if running, and await its cleanup."""
         if task and not task.done():
@@ -351,7 +356,6 @@ class Mqtt:
                 await task
             except asyncio.CancelledError:
                 pass
-
 
     async def stop(self):
         """Clean disconnect from MQTT"""
@@ -377,9 +381,9 @@ class Mqtt:
         # Disconnect current client
         if self._mqttClient:
             await self._mqttClient.__aexit__(None, None, None)
-       
+
         await asyncio.sleep(2)
-        
+
         self._mqttClientID = self._state._mqttClientID = generate_uuid()
         logger.debug(f"Generated new MQTT client ID: {self._mqttClientID}")
         self._sequence_id = await self._fetch_sequence_id(self._state)
@@ -392,14 +396,14 @@ class Mqtt:
             protocol=aiomqtt.ProtocolVersion.V31,
             transport="websockets",
             port=443,
-            keepalive=60
+            keepalive=60,
         )
-        
+
         # Reconnect with new configuration
         self._mqttClient._client.tls_set()
         self._configure_mqtt_options()
         await self._mqttClient.__aenter__()
-        
+
         if self._mqttClient._client.is_connected():
             logger.info("✅ MQTT reconnected successfully")
             self._sync_token = None
@@ -413,7 +417,6 @@ class Mqtt:
             logger.info("✅ Reconnected and restarted listen/presence loops")
         self._reconnecting = False
 
-
     async def _schedule_reconnect(self):
         """Schedule periodic reconnections with random intervals"""
         while self._running:
@@ -425,6 +428,3 @@ class Mqtt:
                 await self._reconnect()
             except Exception as e:
                 logger.error(f"Reconnection failed: {e}")
-
-
-

--- a/fbchat_muqit/state.py
+++ b/fbchat_muqit/state.py
@@ -22,7 +22,15 @@ from puremagic import from_string
 
 # fbchat-muqit imports
 from .graphql import GraphQLProcessor
-from .utils.stateHelper import *
+from .utils.stateHelper import (
+    load_json_cookies_async,
+    cookie_list_to_jar,
+    dump_jar_to_cookie_list,
+    get_user_id,
+    extract_tokens_from_html,
+    client_id_factory,
+    get_session,
+)
 from .logging.logger import get_logger, FBChatLogger
 from .exception.errors import (
     FBChatError,
@@ -31,7 +39,7 @@ from .exception.errors import (
     SessionExpiredError,
     FacebookAPIError,
     NetworkError,
-    handle_exceptions
+    handle_exceptions,
 )
 from .utils.utils import (
     now,
@@ -41,13 +49,12 @@ from .utils.utils import (
     get_jsmods_require,
     generate_message_id,
     generate_offline_threading_id,
-    )
-
+)
 
 __all__ = ["State"]
 
 
-def generate_download_session()->ClientSession:
+def generate_download_session() -> ClientSession:
     return ClientSession()
 
 
@@ -55,15 +62,15 @@ def generate_download_session()->ClientSession:
 class State:
     """
     Modern State class for Facebook session management.
-    
+
     Handles authentication, session state, token management, and API communication.
     """
-    
+
     # User information
     user_id: str = field()
     user_name: str = field()
     _host: str = field()
-    
+
     # Authentication tokens
     _fb_dtsg: str = field()
     _fb_dtsg_ag: str = field()
@@ -74,86 +81,81 @@ class State:
     _mqttClientID: str = field()
     _mqttAppID: str = field()
     _userAppID: str = field()
-    
+
     # MQTT connection details
     _endpoint: str = field()
     _region: str = field()
     _client_id: str = field(default_factory=client_id_factory)
-    
+
     # Session management
     _session: ClientSession = field(default_factory=get_session)
     _counter: int = field(default=0)
     _is_logged: bool = field(default=False)
     _jar: Optional[CookieJar] = field(default=None)
-    
-    
+
     # Auto-refresh configuration
     _last_refresh: float = field(default_factory=time.time)
     _refresh_interval: int = field(default=3600)  # 1 hour
     _auto_refresh_enabled: bool = field(default=True)
-    
+
     # Logging
     _logger: FBChatLogger = field(default_factory=get_logger)
     _graphql: GraphQLProcessor = GraphQLProcessor()
-   
-   # extra session
+
+    # extra session
     _download_session: ClientSession = field(default_factory=generate_download_session)
-    
-
-
 
     # Headers and configuration
-    _userAgent: str =  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
-    
+    _userAgent: str = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36"
+    )
+
     BASE_HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                  "AppleWebKit/537.36 (KHTML, like Gecko) "
-                  "Chrome/137.0.0.0 Safari/537.36",
-    "Accept-Language": "en-US,en;q=0.9",
-    "Accept-Encoding": "gzip, deflate, br",
-    "Connection": "keep-alive",
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/137.0.0.0 Safari/537.36",
+        "Accept-Language": "en-US,en;q=0.9",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
     }
     ALLHEADERS = {
-    "get": {
-        **BASE_HEADERS,
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
-        "Sec-Fetch-User": "?1",
-        "Sec-Fetch-Site": "same-origin",
-        # no Content-Type for GET!
-    },
-    "post": {
-        **BASE_HEADERS,
-        "Accept": "*/*",
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-origin",
-    },
-    "upload": {
-        **BASE_HEADERS,
-        "Sec-Fetch-Mode": "cors",
-        "Sec-Fetch-Site": "same-origin",
-        "Accept": "*/*",
-        # Let aiohttp set multipart Content-Type automatically
+        "get": {
+            **BASE_HEADERS,
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9",
+            "Sec-Fetch-User": "?1",
+            "Sec-Fetch-Site": "same-origin",
+            # no Content-Type for GET!
         },
-    "publish_post": {
-        **BASE_HEADERS,
-        "Accept": "*/*",
-        "Content-Type": "application/x-www-form-urlencoded",
-        }
+        "post": {
+            **BASE_HEADERS,
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+        },
+        "upload": {
+            **BASE_HEADERS,
+            "Sec-Fetch-Mode": "cors",
+            "Sec-Fetch-Site": "same-origin",
+            "Accept": "*/*",
+            # Let aiohttp set multipart Content-Type automatically
+        },
+        "publish_post": {
+            **BASE_HEADERS,
+            "Accept": "*/*",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
     }
 
-
-
-    
     def __post_init__(self):
         """Initialize the State instance."""
-        # do I need to change them here or it will be automatically changed 
+        # do I need to change them here or it will be automatically changed
         # i'm not sure since we aee doing `**BASE_HEADERS`
         self.BASE_HEADERS["User-Agent"] = self._userAgent
-        self.ALLHEADERS["get"]["User-Agent"] = self._userAgent 
+        self.ALLHEADERS["get"]["User-Agent"] = self._userAgent
         self.ALLHEADERS["post"]["User-Agent"] = self._userAgent
         self.ALLHEADERS["upload"]["User-Agent"] = self._userAgent
-        
+
         # Start auto-refresh task if enabled
         # if self._auto_refresh_enabled:
         #     asyncio.create_task(self._auto_refresh_loop())
@@ -162,11 +164,11 @@ class State:
     def is_refresh_needed(self) -> bool:
         """Check if tokens need refreshing based on time interval."""
         return (time.time() - self._last_refresh) > self._refresh_interval
-    
+
     def get_params(self) -> Dict[str, Any]:
         """Get standard necessary parameters for Facebook API requests."""
         self._counter += 1
-        
+
         params = {
             # "av": self.user_id,
             "__user": self.user_id,
@@ -176,12 +178,17 @@ class State:
             "fb_dtsg": self._fb_dtsg,
             "jazoest": self._jazoest,
         }
-        
+
         self._logger.trace(f"Generated request params for counter {self._counter}")
         return params
-    
-    
-    def build_headers(self, url: str, request_type: str = "get", graphql_data: Dict = dict(), user_agent: Optional[str] = None) -> dict:
+
+    def build_headers(
+        self,
+        url: str,
+        request_type: str = "get",
+        graphql_data: Dict = dict(),
+        user_agent: Optional[str] = None,
+    ) -> dict:
         """
         Dynamically build headers for a given URL and request type.
         - request_type: "get", "post", "upload", "graphql", etc.
@@ -193,18 +200,20 @@ class State:
         headers = self.ALLHEADERS.get(request_type, {}).copy()
 
         # Dynamically adjust host-related headers
-        headers.update({
-            "Host": host,
-            "Origin": base_url,
-            "Referer": f"{base_url}/",
-        })
+        headers.update(
+            {
+                "Host": host,
+                "Origin": base_url,
+                "Referer": f"{base_url}/",
+            }
+        )
 
         if user_agent:
             headers["User-Agent"] = user_agent
 
         if "/api/graphql" in url and "fb_api_req_friendly_name" in graphql_data:
             headers["X-Fb-Friendly-Name"] = graphql_data["fb_api_req_friendly_name"]
-            headers["X-Fb-Lsd"] = self._lsd 
+            headers["X-Fb-Lsd"] = self._lsd
 
         # Adjust for Messenger
         if "messenger.com" in host:
@@ -215,123 +224,164 @@ class State:
         elif "rupload" in host or "upload" in request_type:
             headers.pop("Content-Type", None)  # multipart handled automatically
             headers["Accept"] = "*/*"
-        
 
         # Adjust for mobile domain
         if host.startswith("m."):
             headers["Origin"] = "https://m.facebook.com"
             headers["Referer"] = "https://m.facebook.com/"
 
-
         return headers
 
     @classmethod
     @handle_exceptions(AuthenticationError)
     async def from_json_cookies(
-        cls, 
-        json_cookies_path: str, 
-        user_agent: Optional[str] = None, 
-        proxy: Optional[str] = None
+        cls,
+        json_cookies_path: str,
+        user_agent: Optional[str] = None,
+        proxy: Optional[str] = None,
     ) -> State:
         """
         Create State instance from saved Facebook cookies JSON file.
-        
+
         Args:
             json_cookies_path: Path to the saved Facebook cookies JSON file
             user_agent: Optional custom User-Agent string
             proxy: Optional proxy URL
-            
+
         Returns:
             State instance with authenticated session
-            
+
         Raises:
             AuthenticationError: If authentication fails
         """
         logger = get_logger()
         logger.info(f"Creating Session from cookies file: {json_cookies_path}")
-        
+
         try:
-            jar: CookieJar = load_json_cookies(json_cookies_path)
+            jar: CookieJar = await load_json_cookies_async(json_cookies_path)
             session: ClientSession = get_session(jar, proxy)
             return await cls.login(session, jar, user_agent)
         except Exception as e:
             logger.error(f"Failed to create State from cookies: {e}")
             raise AuthenticationError(
                 f"Failed to load session from cookies: {e}",
-                details={'cookies_path': json_cookies_path}
+                details={"cookies_path": json_cookies_path},
             ) from e
-    
+
     @classmethod
     @handle_exceptions(AuthenticationError)
-    async def login(cls, session: ClientSession, jar: Optional[CookieJar], user_agent: Optional[str] = None) -> State:
+    async def from_cookie_list(
+        cls,
+        cookies: List[Dict[str, Any]],
+        user_agent: Optional[str] = None,
+        proxy: Optional[str] = None,
+    ) -> "State":
+        """
+        Restore :class:`State` from serialized cookie list (fbstate format).
+        Use with :meth:`dump_session_snapshot` for persistence without a cookie file.
+        """
+        jar = cookie_list_to_jar(cookies)
+        session: ClientSession = get_session(jar, proxy)
+        return await cls.login(session, jar, user_agent)
+
+    def dump_session_snapshot(self) -> Dict[str, Any]:
+        """Export cookies for JSON/Redis storage; restore via :meth:`from_cookie_list`."""
+        if self._session is None or self._session.cookie_jar is None:
+            raise FBChatError("No active session to serialize")
+        return {
+            "version": 1,
+            "cookies": dump_jar_to_cookie_list(self._session.cookie_jar),
+        }
+
+    @classmethod
+    @handle_exceptions(AuthenticationError)
+    async def login(
+        cls,
+        session: ClientSession,
+        jar: Optional[CookieJar],
+        user_agent: Optional[str] = None,
+    ) -> State:
         """
         Create State instance from existing aiohttp session.
-        
+
         Args:
             session (ClientSession): Authenticated aiohttp ClientSession
             jar (CookieJar): Cookie jar from the session
-            
+
         Returns:
             State (State): instance with session data
-            
+
         Raises:
             AuthenticationError: If session is invalid or extraction fails
         """
+        logger = get_logger()
         try:
             user_id = get_user_id(session)
             logger.debug(f"Extracted user ID: {user_id}")
-            
+
             # Initial URL and host determination
             url = "https://www.facebook.com/"
             host = "www.facebook.com"
-            
+
             logger.debug(f"Making initial request to: {url}")
-            
+
             headers = cls.ALLHEADERS["get"]
             headers["User-Agent"] = user_agent or headers["User-Agent"]
             headers["Host"] = host
             headers["Origin"] = url.removesuffix("/")
             headers["Referer"] = url
-            
-            async with session.get(url, headers=headers, allow_redirects=False) as response:
+
+            async with session.get(
+                url, headers=headers, allow_redirects=False
+            ) as response:
                 if 300 <= response.status < 400:
                     # Handle redirects to different Facebook domains
-                    location = response.headers.get('Location')
+                    location = response.headers.get("Location")
                     if location:
                         host = str(URL(str(location)).host)
                         url = f"https://{host}/"
-                        origin =  f"https://{host}"
-                        
+                        origin = f"https://{host}"
+
                         logger.debug(f"Redirected to: {host}")
-                        
+
                         # Update session headers for new host
-                        headers.update({
-                            "Host": host,
-                            "Origin": origin,
-                            "Referer": url
-                        })
-                        
+                        headers.update({"Host": host, "Origin": origin, "Referer": url})
+
                         response = await session.get(url, headers=headers)
                 else:
-                    logger.debug(f"Direct response from {host}, status: {response.status}")
-                
+                    logger.debug(
+                        f"Direct response from {host}, status: {response.status}"
+                    )
+
                 if response.status != 200:
                     raise NetworkError(
                         f"Failed to fetch Facebook page: HTTP {response.status}",
-                        error_code=str(response.status)
+                        error_code=str(response.status),
                     )
-                
+
                 html_content = await response.text()
                 logger.debug(f"Received HTML content: {len(html_content)} characters")
-                
+
                 # Save HTML for debugging if needed
                 # save_html(html_content)
-            
+
             # Extract tokens and configuration from HTML
             logger.debug("Extracting tokens from HTML content")
-            (fb_dtsg, fb_dtsg_ag, lsd, jazoest, jazoest_async, client_revision, mqttClientID, 
-             mqttAppID, userAppID, endpoint, region, user_name) = extract_tokens_from_html(html_content)
-            
+            (
+                fb_dtsg,
+                fb_dtsg_ag,
+                lsd,
+                jazoest,
+                jazoest_async,
+                client_revision,
+                mqttClientID,
+                mqttAppID,
+                userAppID,
+                endpoint,
+                region,
+                user_name,
+            ) = extract_tokens_from_html(html_content)
+
             # Create State instance
             state = cls(
                 user_id=user_id,
@@ -352,44 +402,47 @@ class State:
                 _is_logged=True,
                 _jar=jar,
                 _last_refresh=time.time(),
-                _userAgent=user_agent or cls.BASE_HEADERS["User-Agent"], 
+                _userAgent=user_agent or cls.BASE_HEADERS["User-Agent"],
             )
-            
+
             logger.debug("Extracted tokens and State instance created successfully")
             return state
-            
+
         except Exception as e:
             logger.error(f"Failed to create State from session: {e}")
             if isinstance(e, FBChatError):
                 raise
             raise AuthenticationError(
-                f"Failed to extract session data: {e}",
-                original_exception=e
+                f"Failed to extract session data: {e}", original_exception=e
             ) from e
-    
+
     def is_logged_in(self) -> bool:
         """Check if the session is currently logged in."""
         return self._is_logged
-    
+
     def get_cookies(self) -> Dict[str, str]:
         """Get current session cookies."""
-        cookies = self._session.cookie_jar.filter_cookies(URL("https://www.facebook.com"))
+        cookies = self._session.cookie_jar.filter_cookies(
+            URL("https://www.facebook.com")
+        )
         return {name: cookie.value for name, cookie in cookies.items()}
-    
+
     @handle_exceptions(AuthenticationError)
     async def _refresh(self) -> None:
         """
         Refresh authentication tokens and session state.
-        
+
         Raises:
             AuthenticationError: If refresh fails
         """
         self._logger.info("Refreshing session tokens and state")
-        
+
         try:
             # Create new State from current session
-            new_state = await State.login(session=self._session, jar=self._jar, user_agent=self._userAgent)
-            
+            new_state = await State.login(
+                session=self._session, jar=self._jar, user_agent=self._userAgent
+            )
+
             # Update current instance with new data
             self.user_id = new_state.user_id
             self.user_name = new_state.user_name
@@ -408,66 +461,65 @@ class State:
             self._jar = new_state._jar
             self._last_refresh = time.time()
             self._userAgent = new_state._userAgent or self.BASE_HEADERS["User-Agent"]
-            
+
             self._logger.info("Session refresh completed successfully")
-            
+
         except Exception as e:
             self._logger.error(f"Session refresh failed: {e}")
             self._is_logged = False
             raise AuthenticationError(
-                f"Failed to refresh session: {e}",
-                original_exception=e
+                f"Failed to refresh session: {e}", original_exception=e
             ) from e
-    
+
     async def _auto_refresh_loop(self) -> None:
         """Background task for automatic token refresh."""
         self._logger.debug("Starting auto-refresh loop")
-        
+
         while self._auto_refresh_enabled and self._is_logged:
             try:
                 await asyncio.sleep(300)  # Check every 5 minutes
-                
+
                 if self.is_refresh_needed:
                     self._logger.info("Auto-refresh triggered")
                     await self._refresh()
-                    
+
             except asyncio.CancelledError:
                 self._logger.debug("Auto-refresh loop cancelled")
                 break
             except Exception as e:
                 self._logger.error(f"Auto-refresh loop error: {e}")
                 await asyncio.sleep(60)  # Wait before retrying
-    
+
     def enable_auto_refresh(self, interval: int = 3600) -> None:
         """
         Enable automatic token refresh.
-        
+
         Args:
             interval: Refresh interval in seconds (default: 1 hour)
         """
         self._refresh_interval = interval
         self._auto_refresh_enabled = True
         self._logger.info(f"Auto-refresh enabled with {interval}s interval")
-        
+
         # Start the loop if not already running
         asyncio.create_task(self._auto_refresh_loop())
-    
+
     def disable_auto_refresh(self) -> None:
         """Disable automatic token refresh."""
         self._auto_refresh_enabled = False
         self._logger.debug("Auto-refresh disabled")
-    
+
     @handle_exceptions(NetworkError)
     async def _check_request(self, response: aiohttp.ClientResponse) -> str:
         """
         Check HTTP response and extract content.
-        
+
         Args:
             response: aiohttp response object
-            
+
         Returns:
             Response content as string
-            
+
         Raises:
             NetworkError: If request failed
         """
@@ -475,46 +527,46 @@ class State:
         if response.status == 404:
             raise NetworkError(
                 f"HTTP 404: Invalid URL or ID. Status: {response.status}",
-                error_code=str(response.status)
+                error_code=str(response.status),
             )
         elif 400 <= response.status < 600:
             raise NetworkError(
-                f"HTTP error: {response.status}",
-                error_code=str(response.status)
+                f"HTTP error: {response.status}", error_code=str(response.status)
             )
-        
+
         # Get response content
         content = await response.text(encoding="utf-8")
-        
+
         if not content:
             raise NetworkError("Empty response received")
-        
-        self._logger.debug(f"Request successful: {response.status}, content: {len(content)} chars")
+
+        self._logger.debug(
+            f"Request successful: {response.status}, content: {len(content)} chars"
+        )
         return content
-    
+
     @handle_exceptions(FacebookAPIError)
     async def _get(
-        self, 
-        url: str, 
-        params: Optional[Dict[str, Any]] = None, 
+        self,
+        url: str,
+        params: Optional[Dict[str, Any]] = None,
         data: Optional[Dict] = None,
-        error_retries: int = 3
+        error_retries: int = 3,
     ) -> Dict[str, Any]:
         """
         Perform GET request to Facebook API.
-        
+
         Args:
             url: Request URL
             params: Query parameters
             error_retries: Number of retry attempts
-            
+
         Returns:
             Parsed JSON response
-            
+
         Raises:
             FacebookAPIError: If API returns an error
         """
-
 
         full_url = prefix_url(url, self._host)
         if params is None:
@@ -526,34 +578,36 @@ class State:
             p.pop("jazoest")
         p.update(params)
         params = p
-        # Configure headers 
+        # Configure headers
         headers = self.build_headers(full_url)
 
-        
         self._logger.log_api_request("GET", full_url, data=params)
-        
+
         try:
-            async with self._session.get(full_url, params=params, data=data, headers=headers) as response:
+            async with self._session.get(
+                full_url, params=params, data=data, headers=headers
+            ) as response:
                 content = await self._check_request(response)
-                
+
             json_data = self._graphql.process_normal_response(content)
-            
+
             # Check for payload errors using modern GraphQL processor
             self._graphql.handle_payload_error(json_data)
-            
+
             self._logger.log_api_response(response.status, full_url)
             return json_data
-            
+
         except FBChatError as e:
-            if error_retries > 0 and isinstance(e, (SessionExpiredError, FacebookAPIError)):
-                self._logger.warning(f"Request failed, retrying... ({error_retries} attempts left)")
+            if error_retries > 0 and isinstance(
+                e, (SessionExpiredError, FacebookAPIError)
+            ):
+                self._logger.warning(
+                    f"Request failed, retrying... ({error_retries} attempts left)"
+                )
                 await self._refresh()
                 return await self._get(url, params, error_retries=error_retries - 1)
             raise
 
-
-
-    
     @handle_exceptions(FacebookAPIError)
     async def _post(
         self,
@@ -566,21 +620,21 @@ class State:
         headers: dict | None = None,
         no_response: bool = False,
         params: Dict | None = None,
-        header_type = "post",
+        header_type="post",
     ) -> Any:
         """
         Perform POST request to Facebook API.
-        
+
         Args:
             url: Request URL
             data: POST data
             files: File attachments
             as_graphql: Whether to process as GraphQL response
             error_retries: Number of retry attempts
-            
+
         Returns:
             Parsed response data
-            
+
         Raises:
             FacebookAPIError: If API returns an error
         """
@@ -591,58 +645,66 @@ class State:
         full_url = prefix_url(url, self._host)
         data = data or {}
 
-
         if files:
             copied_headers = self.build_headers(full_url, "upload")
         else:
-            copied_headers = self.build_headers(full_url, header_type, graphql_data=data)
+            copied_headers = self.build_headers(
+                full_url, header_type, graphql_data=data
+            )
 
         if headers:
             copied_headers.update(headers)
-    
+
         # Handle file uploads
         if files:
             form_data = aiohttp.FormData()
             for key, value in data.items():
                 form_data.add_field(key, str(value))
             for k, (filename, file_obj, content_type) in files.items():
-                    form_data.add_field(k, file_obj, filename=filename, content_type=content_type)
-            
-            data = form_data  #type: ignore
+                form_data.add_field(
+                    k, file_obj, filename=filename, content_type=content_type
+                )
 
+            data = form_data  # type: ignore
 
             # Let aiohttp handle Content-Type for multipart
             # copied_headers.pop("Content-Type", None)
-        
-        self._logger.log_api_request("POST", full_url, data=data if not files else "multipart")
+
+        self._logger.log_api_request(
+            "POST", full_url, data=data if not files else "multipart"
+        )
         try:
-            async with self._session.post(full_url, data=data, headers=copied_headers, params=params) as response:
+            async with self._session.post(
+                full_url, data=data, headers=copied_headers, params=params
+            ) as response:
 
                 if raw:
                     return await response.read()
                 elif no_response:
                     return
                 content = await self._check_request(response)
-            
+
             # Process response based on type
             if as_graphql:
                 result = self._graphql.process_response(content)
             else:
                 result = self._graphql.process_normal_response(content)
                 self._graphql.handle_payload_error(result)
-            
+
             self._logger.log_api_response(response.status, full_url)
             return result
-            
+
         except FBChatError as e:
-            if error_retries > 0 and isinstance(e, (SessionExpiredError, FacebookAPIError)):
-                self._logger.warning(f"Request failed, retrying... ({error_retries} attempts left)")
+            if error_retries > 0 and isinstance(
+                e, (SessionExpiredError, FacebookAPIError)
+            ):
+                self._logger.warning(
+                    f"Request failed, retrying... ({error_retries} attempts left)"
+                )
                 # await self._refresh()
                 # return await self._post(url, data, files, as_graphql, error_retries - 1)
                 self._logger.info(f"error: {e}")
             raise
-
-
 
     async def _option(self, url: str, params: Dict, headers: Dict):
         """Right now this function only used during facebook video upload."""
@@ -650,113 +712,117 @@ class State:
         new_header = self.build_headers(url, "upload")
         new_header.update(headers)
         try:
-            async with self._session.options(url, params=params, headers=new_header) as response:
+            async with self._session.options(
+                url, params=params, headers=new_header
+            ) as response:
                 if response.status == 200:
                     self._logger.debug("Successfully sent `OPTIONS` request.")
                 else:
-                    self._logger.debug(f"`OPTIONS` requests wasn't successfull. Response Status: {response.status}")
+                    self._logger.debug(
+                        f"`OPTIONS` requests wasn't successfull. Response Status: {response.status}"
+                    )
         except Exception as e:
-            FBChatError(f"Error while sending `OPTION` request.", original_exception=e)
-
+            FBChatError("Error while sending `OPTION` request.", original_exception=e)
 
     @handle_exceptions(FacebookAPIError)
     async def _payload_post(
         self,
         url: str,
         data: Dict[str, Any],
-        files: Optional[Dict[str, Tuple[str, Any, str]]] = None
+        files: Optional[Dict[str, Tuple[str, Any, str]]] = None,
     ) -> Dict[str, Any]:
         """
         Perform POST request and extract payload from response.
-        
+
         Args:
             url: Request URL
             data: POST data
             files: File attachments
-            
+
         Returns:
             Payload data from response
-            
+
         Raises:
             FacebookAPIError: If payload is missing or invalid
         """
         response = await self._post(url, data=data, files=files)
-        
+
         try:
             return response["payload"]
         except (KeyError, TypeError) as e:
             raise FacebookAPIError(
-                "Missing or invalid payload in response",
-                details={'response': response}
+                "Missing or invalid payload in response", details={"response": response}
             ) from e
-    
+
     @handle_exceptions(FacebookAPIError)
     async def _graphql_requests(self, *queries) -> List[Optional[Dict[str, Any]]]:
         """
         Execute multiple GraphQL queries in a batch.
-        
+
         Args:
             queries: GraphQL query objects
-            
+
         Returns:
             List of query results
-            
+
         Raises:
             FacebookAPIError: If GraphQL request fails
         """
-        
+
         data = {
             "method": "GET",
             "response_format": "json",
             "queries": self._graphql.queries_to_json(*queries),
         }
-        
+
         self._logger.debug(f"Executing {len(queries)} GraphQL queries")
         return await self._post("/api/graphqlbatch/", data, as_graphql=True)
-    
+
     @handle_exceptions(FacebookAPIError)
     async def _upload(
-        self, 
-        files: List[Tuple[str, Any, str]], 
+        self,
+        files: List[Tuple[str, Any, str]],
         voice_clip: bool = True,
-        full_data: bool = False
+        full_data: bool = False,
     ) -> List[int]:
         """
         Upload files to Facebook.
-        
+
         Args:
             files: List of (filename, file_object, content_type) tuples
             voice_clip: Whether files are voice clips
-            
+
         Returns:
             List of (file_id, content_type) tuples
-            
+
         Raises:
             FacebookAPIError: If upload fails
         """
-        file_dict ={f"upload_{i}": file_data for i, file_data in enumerate(files)}
+        file_dict = {f"upload_{i}": file_data for i, file_data in enumerate(files)}
         data = {"voice_clip": "true" if voice_clip else "false"}
-        
+
         self._logger.info(f"Uploading {len(files)} files (voice_clip: {voice_clip})")
-        
+
         json_response = await self._post(
-            "https://upload.facebook.com/ajax/mercury/upload.php", 
-            data=data, 
-            files=file_dict
+            "https://upload.facebook.com/ajax/mercury/upload.php",
+            data=data,
+            files=file_dict,
         )
         json_response = json_response["payload"]
-        
+
         if len(json_response["metadata"]) != len(files):
             raise FacebookAPIError(
                 "Some files could not be uploaded",
-                details={'response': json_response, 'files_count': len(files)}
+                details={"response": json_response, "files_count": len(files)},
             )
 
-        self._logger.debug(f"Successfully uploaded {len(json_response['metadata'])}/{len(files)} files")
+        self._logger.debug(
+            f"Successfully uploaded {len(json_response['metadata'])}/{len(files)} files"
+        )
 
         # Extract file IDs and types
-        
-            # extract only Id
+
+        # extract only Id
 
         if full_data:
             results = []
@@ -773,52 +839,54 @@ class State:
     async def download_file(self, url, filename):
         async with self._download_session.get(url) as resp:
             resp.raise_for_status()
-            async with aiofiles.open(filename, 'wb') as f:
+            async with aiofiles.open(filename, "wb") as f:
                 async for chunk in resp.content.iter_chunked(1024 * 64):
                     await f.write(chunk)
         self._logger.info(f"Downloaded: {filename}")
-
-
 
     @handle_exceptions(FacebookAPIError)
     async def send_request(self, data: Dict[str, Any]) -> Tuple[str, str]:
         # not used anymore
         """
         Send a message request to Facebook.
-        
+
         Args:
             data: Message data
-            
+
         Returns:
             Tuple of (message_id, thread_id)
-            
+
         Raises:
             FacebookAPIError: If sending fails
         """
         offline_threading_id = generate_offline_threading_id()
-        
+
         # Prepare message data
-        data.update({
-            "client": "mercury",
-            "author": f"fbid:{self.user_id}",
-            "timestamp": now(),
-            "source": "source:chat:web",
-            "offline_threading_id": offline_threading_id,
-            "message_id": offline_threading_id,
-            "threading_id": generate_message_id(self._client_id),
-            "ephemeral_ttl_mode": "0"
-        })
-        
-        self._logger.debug(f"Sending message request for thread: {data.get('thread_fbid', 'unknown')}")
-        
+        data.update(
+            {
+                "client": "mercury",
+                "author": f"fbid:{self.user_id}",
+                "timestamp": now(),
+                "source": "source:chat:web",
+                "offline_threading_id": offline_threading_id,
+                "message_id": offline_threading_id,
+                "threading_id": generate_message_id(self._client_id),
+                "ephemeral_ttl_mode": "0",
+            }
+        )
+
+        self._logger.debug(
+            f"Sending message request for thread: {data.get('thread_fbid', 'unknown')}"
+        )
+
         json_response = await self._post("/messaging/send/", data)
-        
+
         # Update fb_dtsg token if received
         fb_dtsg = get_jsmods_require(json_response, 2)
         if fb_dtsg:
             self._fb_dtsg = fb_dtsg
             self._logger.trace("Updated fb_dtsg token from response")
-        
+
         # Extract message IDs
         try:
             message_ids = [
@@ -826,47 +894,52 @@ class State:
                 for action in json_response["payload"]["actions"]
                 if "message_id" in action
             ]
-            
+
             if len(message_ids) != 1:
-                self._logger.warning(f"Got {len(message_ids)} message IDs back: {message_ids}")
-            
+                self._logger.warning(
+                    f"Got {len(message_ids)} message IDs back: {message_ids}"
+                )
+
             if not message_ids:
                 raise FacebookAPIError(
                     "No message IDs found in response",
-                    details={'response': json_response}
+                    details={"response": json_response},
                 )
-            
+
             message_id, thread_id = message_ids[0]
-            self._logger.debug(f"Message sent successfully: {message_id} in thread {thread_id}")
+            self._logger.debug(
+                f"Message sent successfully: {message_id} in thread {thread_id}"
+            )
             return message_id, thread_id
-            
+
         except (KeyError, IndexError, TypeError) as e:
             raise FacebookAPIError(
                 "Failed to extract message ID from response",
-                details={'response': json_response}
+                details={"response": json_response},
             ) from e
-    
+
     @asynccontextmanager
     async def get_files_from_paths(self, file_paths: List[str]):
         """
         Context manager for handling file uploads.
-        
+
         Args:
             file_paths: List of file paths to upload
-            
+
         Yields:
             List of (filename, file_object, content_type) tuples
         """
         files = []
         for file_path in file_paths:
-            file_obj = open(file_path, "rb").read()
+            async with aiofiles.open(file_path, "rb") as f:
+                file_obj = await f.read()
             content_type = from_string(file_obj, True)
             filename = basename(file_path)
 
             files.append((filename, file_obj, content_type))
-        
+
         yield files
-            
+
         # finally:
         #     # Ensure all files are closed
         #     for filename, file_obj, content_type in files:
@@ -875,8 +948,7 @@ class State:
         #         except Exception as e:
         #             self._logger.warning(f"Failed to close file {filename}: {e}")
 
-
-    async def get_files_from_urls(self, file_urls)-> List[Tuple[str, bytes, str]]:
+    async def get_files_from_urls(self, file_urls) -> List[Tuple[str, bytes, str]]:
         files = []
         async with aiohttp.ClientSession() as session:
             for file_url in file_urls:
@@ -884,11 +956,13 @@ class State:
                     if response.status != 200:
                         raise ResponseError(
                             error_code=str(response.status),
-                            message=f"Failed to fetch {file_url}"
+                            message=f"Failed to fetch {file_url}",
                         )
                     file_name = basename(file_url).split("?")[0].split("#")[0]
                     content = await response.read()  # Read the content as bytes
-                    content_type = response.headers.get("Content-Type") or from_string(content, True)
+                    content_type = response.headers.get("Content-Type") or from_string(
+                        content, True
+                    )
                     files.append(
                         (
                             file_name,
@@ -897,28 +971,28 @@ class State:
                         )
                     )
         return files
-    
+
     async def close(self) -> None:
         """Clean up resources and close connections."""
         self._logger.info("Closing State session")
-        
+
         # Disable auto-refresh
         self.disable_auto_refresh()
-        
+
         # Close session
         if not self._download_session.closed:
             await self._download_session.close()
 
         if self._session and not self._session.closed:
             await self._session.close()
-        
+
         self._is_logged = False
         self._logger.info("State session closed")
-    
+
     async def __aenter__(self):
         """Async context manager entry."""
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         """Async context manager exit."""
         await self.close()

--- a/fbchat_muqit/storage/__init__.py
+++ b/fbchat_muqit/storage/__init__.py
@@ -1,0 +1,14 @@
+"""Persistent session storage backends."""
+
+from .base import SessionStorage
+from .json_store import JsonSessionStorage
+
+__all__ = ["SessionStorage", "JsonSessionStorage", "RedisSessionStorage"]
+
+
+def __getattr__(name: str):
+    if name == "RedisSessionStorage":
+        from .redis_store import RedisSessionStorage
+
+        return RedisSessionStorage
+    raise AttributeError(name)

--- a/fbchat_muqit/storage/base.py
+++ b/fbchat_muqit/storage/base.py
@@ -1,0 +1,16 @@
+"""Abstract session persistence API."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SessionStorage(Protocol):
+    """Persist serialized session snapshots (cookies + metadata)."""
+
+    async def save(self, client_id: str, snapshot: Dict[str, Any]) -> None: ...
+
+    async def load(self, client_id: str) -> Optional[Dict[str, Any]]: ...
+
+    async def delete(self, client_id: str) -> None: ...

--- a/fbchat_muqit/storage/json_store.py
+++ b/fbchat_muqit/storage/json_store.py
@@ -1,0 +1,45 @@
+"""JSON file–backed session storage (default)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import aiofiles
+
+
+def _safe_client_id(client_id: str) -> str:
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in client_id)
+
+
+class JsonSessionStorage:
+    """Store one JSON file per ``client_id`` under ``directory``."""
+
+    __slots__ = ("_dir",)
+
+    def __init__(self, directory: str | Path) -> None:
+        self._dir = Path(directory)
+        self._dir.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, client_id: str) -> Path:
+        return self._dir / f"{_safe_client_id(client_id)}.json"
+
+    async def save(self, client_id: str, snapshot: Dict[str, Any]) -> None:
+        path = self._path(client_id)
+        async with aiofiles.open(path, "w", encoding="utf-8") as f:
+            await f.write(json.dumps(snapshot, indent=2))
+
+    async def load(self, client_id: str) -> Optional[Dict[str, Any]]:
+        path = self._path(client_id)
+        if not path.is_file():
+            return None
+        async with aiofiles.open(path, "r", encoding="utf-8") as f:
+            return json.loads(await f.read())
+
+    async def delete(self, client_id: str) -> None:
+        path = self._path(client_id)
+        try:
+            path.unlink()
+        except OSError:
+            pass

--- a/fbchat_muqit/storage/redis_store.py
+++ b/fbchat_muqit/storage/redis_store.py
@@ -1,0 +1,48 @@
+"""Optional Redis-backed session storage."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+
+try:
+    import redis.asyncio as redis  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - optional dependency
+    redis = None  # type: ignore[assignment]
+
+
+class RedisSessionStorage:
+    """Persist session JSON blobs in Redis."""
+
+    __slots__ = ("_url", "_prefix", "_client")
+
+    def __init__(self, url: str, *, key_prefix: str = "fbchat:session:") -> None:
+        if redis is None:
+            raise ImportError(
+                "RedisSessionStorage requires the 'redis' package. "
+                "Install with: pip install 'fbchat-muqit[redis]' or pip install redis"
+            )
+        self._url = url
+        self._prefix = key_prefix
+        self._client: Any = None
+
+    async def _conn(self) -> Any:
+        if self._client is None:
+            self._client = redis.from_url(self._url, decode_responses=True)
+        return self._client
+
+    async def save(self, client_id: str, snapshot: Dict[str, Any]) -> None:
+        r = await self._conn()
+        await r.set(self._prefix + client_id, json.dumps(snapshot))
+
+    async def load(self, client_id: str) -> Optional[Dict[str, Any]]:
+        r = await self._conn()
+        raw = await r.get(self._prefix + client_id)
+        if raw is None:
+            return None
+        return json.loads(raw)
+
+    async def delete(self, client_id: str) -> None:
+        r = await self._conn()
+        await r.delete(self._prefix + client_id)

--- a/fbchat_muqit/utils/stateHelper.py
+++ b/fbchat_muqit/utils/stateHelper.py
@@ -1,5 +1,9 @@
-import random, re
+import random
+import re
 import json
+from typing import Any, List
+
+import aiofiles
 
 from aiohttp import ClientSession, CookieJar
 from aiohttp_socks import ProxyConnector
@@ -7,21 +11,21 @@ from typing import Tuple, Optional
 from yarl import URL
 from http.cookies import SimpleCookie
 
-from ..logging.logger import get_logger 
+from ..logging.logger import get_logger
 from ..exception.errors import FBChatError, ValidationError
+
 logger = get_logger()
 
-def get_session(cookie_jar: Optional[CookieJar] = None, proxy: Optional[str] = None)-> ClientSession:
+
+def get_session(
+    cookie_jar: Optional[CookieJar] = None, proxy: Optional[str] = None
+) -> ClientSession:
     if proxy:
         connector = ProxyConnector.from_url(proxy)
     else:
         connector = None
 
-    return ClientSession(
-            cookie_jar=cookie_jar,
-            connector=connector
-            )
-
+    return ClientSession(cookie_jar=cookie_jar, connector=connector)
 
 
 def load_json_cookies(json_path: str) -> CookieJar:
@@ -43,7 +47,11 @@ def load_json_cookies(json_path: str) -> CookieJar:
             continue
 
         # Prepare separate SimpleCookie for each domain
-        for domain_url in ("https://www.facebook.com", "https://www.messenger.com", "https://rupload-ccu1-2.up.facebook.com"):
+        for domain_url in (
+            "https://www.facebook.com",
+            "https://www.messenger.com",
+            "https://rupload-ccu1-2.up.facebook.com",
+        ):
             domain = ".messenger.com" if "messenger" in domain_url else ".facebook.com"
             if "rupload" in domain_url:
                 domain = "up.facebook.com"
@@ -60,22 +68,122 @@ def load_json_cookies(json_path: str) -> CookieJar:
     return jar
 
 
-def get_user_id(session: ClientSession)-> str:
-        cookies = session.cookie_jar.filter_cookies(URL("https://www.facebook.com"))
-        CookiesDict = {name: cookie.value for name, cookie in cookies.items()}
-        return str(CookiesDict.get("c_user"))
+async def load_json_cookies_async(json_path: str) -> CookieJar:
+    """Load cookies from JSON path without blocking the event loop."""
+    async with aiofiles.open(json_path, "r", encoding="utf-8") as f:
+        raw = await f.read()
+    data = json.loads(raw)
+
+    if not data or not isinstance(data, list):
+        raise FBChatError("Invalid fbstate format. Expected a list of cookie objects.")
+
+    key_name = "key" if "key" in data[0] else "name"
+
+    jar = CookieJar()
+    for cookie in data:
+        name = cookie.get(key_name)
+        value = cookie.get("value")
+        path = cookie.get("path", "/")
+        if not name or value is None:
+            continue
+
+        for domain_url in (
+            "https://www.facebook.com",
+            "https://www.messenger.com",
+            "https://rupload-ccu1-2.up.facebook.com",
+        ):
+            domain = ".messenger.com" if "messenger" in domain_url else ".facebook.com"
+            if "rupload" in domain_url:
+                domain = "up.facebook.com"
+            sc = SimpleCookie()
+            sc[name] = value
+            sc[name]["domain"] = domain
+            sc[name]["path"] = path
+            if "expires" in cookie:
+                sc[name]["expires"] = cookie["expires"]
+            jar.update_cookies(sc, URL(domain_url))
+
+    logger.info(f" ✅ Succssfully loaded Cookies into Jar from {json_path} (async)")
+    return jar
 
 
-def client_id_factory()-> str:
-      return hex(int(random.random() * 2 ** 31))[2:]
+def cookie_list_to_jar(data: List[dict[str, Any]]) -> CookieJar:
+    """Build a :class:`CookieJar` from a list of cookie dicts (fbstate format)."""
+    if not data or not isinstance(data, list):
+        raise FBChatError("Invalid cookie data. Expected a list of cookie objects.")
+
+    key_name = "key" if "key" in data[0] else "name"
+
+    jar = CookieJar()
+    for cookie in data:
+        name = cookie.get(key_name)
+        value = cookie.get("value")
+        path = cookie.get("path", "/")
+        if not name or value is None:
+            continue
+
+        for domain_url in (
+            "https://www.facebook.com",
+            "https://www.messenger.com",
+            "https://rupload-ccu1-2.up.facebook.com",
+        ):
+            domain = ".messenger.com" if "messenger" in domain_url else ".facebook.com"
+            if "rupload" in domain_url:
+                domain = "up.facebook.com"
+            sc = SimpleCookie()
+            sc[name] = value
+            sc[name]["domain"] = domain
+            sc[name]["path"] = path
+            if "expires" in cookie:
+                sc[name]["expires"] = cookie["expires"]
+            jar.update_cookies(sc, URL(domain_url))
+
+    return jar
+
+
+def dump_jar_to_cookie_list(jar: CookieJar) -> List[dict[str, Any]]:
+    """Serialize a :class:`CookieJar` to fbstate-compatible cookie dicts."""
+    out: List[dict[str, Any]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for url in (
+        "https://www.facebook.com",
+        "https://www.messenger.com",
+        "https://rupload-ccu1-2.up.facebook.com",
+    ):
+        filtered = jar.filter_cookies(URL(url))
+        for name, morsel in filtered.items():
+            dom = str(morsel.get("domain", "") or "")
+            key = (name, morsel.value, dom)
+            if key in seen:
+                continue
+            seen.add(key)
+            d: dict[str, Any] = {
+                "name": name,
+                "value": morsel.value,
+                "path": morsel.get("path", "/"),
+            }
+            if morsel.get("expires"):
+                d["expires"] = morsel["expires"]
+            out.append(d)
+    return out
+
+
+def get_user_id(session: ClientSession) -> str:
+    cookies = session.cookie_jar.filter_cookies(URL("https://www.facebook.com"))
+    CookiesDict = {name: cookie.value for name, cookie in cookies.items()}
+    return str(CookiesDict.get("c_user"))
+
+
+def client_id_factory() -> str:
+    return hex(int(random.random() * 2**31))[2:]
+
 
 def save_html(html):
     with open("./test.html", "w") as f:
         f.write(html)
 
 
-
-def extract_tokens_from_html(html: str)->Tuple:
+def extract_tokens_from_html(html: str) -> Tuple:
     """Extracts fb_dtsg, client_revision, mqttAppID etc. from HTML response to Login in facebook"""
 
     fb_dtsg = re.search(r'"DTSGInitialData".*?"token":"(.*?)"', html)
@@ -85,26 +193,29 @@ def extract_tokens_from_html(html: str)->Tuple:
         raise ValidationError("'fb_dtsg' token not found.")
 
     pattern = r'"DTSGInitData"(?:\s*,\s*\[\])?(?:\s*,\s*)\{[^}]*"async_get_token"\s*:\s*"([^"]+)"[^}]*\}'
-        
+
     fb_dtsg_ag = re.search(pattern, html)
     if fb_dtsg_ag:
         fb_dtsg_ag = fb_dtsg_ag.group(1)
     else:
         raise ValidationError("'async_get_token' not found.")
 
-    lsd_token = re.search(r'"LSD"\s*,\s*\[\s*\]\s*,\s*\{\s*"token"\s*:\s*"([A-Za-z0-9_-]+)"', html)
+    lsd_token = re.search(
+        r'"LSD"\s*,\s*\[\s*\]\s*,\s*\{\s*"token"\s*:\s*"([A-Za-z0-9_-]+)"', html
+    )
     if lsd_token:
         lsd_token = lsd_token.group(1)
 
     jazoest = "2" + str(sum(ord(c) for c in fb_dtsg))
-    jazoest_async =  "2" + str(sum(ord(c) for c in fb_dtsg_ag))
-
+    jazoest_async = "2" + str(sum(ord(c) for c in fb_dtsg_ag))
 
     clientRevision = re.search(r'client_revision":(\d+)', html)
     if clientRevision:
         clientRevision = int(clientRevision.group(1))
 
-    clientID = re.search(r'\["MqttWebDeviceID".*?"clientID"\s*:\s*"([a-f0-9\-]+)"', html)
+    clientID = re.search(
+        r'\["MqttWebDeviceID".*?"clientID"\s*:\s*"([a-f0-9\-]+)"', html
+    )
     if clientID:
         clientID = clientID.group(1)
 
@@ -116,11 +227,13 @@ def extract_tokens_from_html(html: str)->Tuple:
     if userAppID:
         userAppID = userAppID.group(1)
 
-    # Extracting Mqtt endpoint for facebook 
-    mqttEndpoint = re.search(r'"endpoint"\s*:\s*"([^"]*?region=([a-zA-Z0-9_-]+)[^"]*)"', html)
+    # Extracting Mqtt endpoint for facebook
+    mqttEndpoint = re.search(
+        r'"endpoint"\s*:\s*"([^"]*?region=([a-zA-Z0-9_-]+)[^"]*)"', html
+    )
     if not mqttEndpoint:
         raise ValueError("Mqtt Endpoint not found!")
-    endpoint = mqttEndpoint.group(1).encode().decode('unicode_escape')
+    endpoint = mqttEndpoint.group(1).encode().decode("unicode_escape")
     region = mqttEndpoint.group(2)
 
     user_name = re.search(r'"NAME"\s*:\s*"([^"]+)"', html)
@@ -128,15 +241,28 @@ def extract_tokens_from_html(html: str)->Tuple:
         user_name = user_name.group(1)
         logger.debug(f"User name: {user_name}")
 
-    logger.debug(f"fb dtag: {fb_dtsg}") # used for post requests
-    logger.debug(f"fb dtsg async: {fb_dtsg_ag}") # used for get requests
+    logger.debug(f"fb dtag: {fb_dtsg}")  # used for post requests
+    logger.debug(f"fb dtsg async: {fb_dtsg_ag}")  # used for get requests
     logger.debug(f"LSD token: {lsd_token}")
-    logger.debug(f"jazoest: {jazoest}") # used for post requests
-    logger.debug(f"jazoest async: {jazoest_async}") # used for get request
+    logger.debug(f"jazoest: {jazoest}")  # used for post requests
+    logger.debug(f"jazoest async: {jazoest_async}")  # used for get request
     logger.debug(f"client revision: {clientRevision}")
     logger.debug(f"client id(uuid): {clientID}")
     logger.debug(f"mqttAppID: {mqttAppID}")
-    logger.debug(f"User App_ID: {userAppID}")        
+    logger.debug(f"User App_ID: {userAppID}")
     logger.debug(f"Mqtt Endpoint URL: {endpoint}")
     logger.debug(f"Region: {region}")
-    return (fb_dtsg, fb_dtsg_ag, lsd_token, jazoest, jazoest_async, clientRevision, clientID, mqttAppID, userAppID, endpoint, region, user_name)
+    return (
+        fb_dtsg,
+        fb_dtsg_ag,
+        lsd_token,
+        jazoest,
+        jazoest_async,
+        clientRevision,
+        clientID,
+        mqttAppID,
+        userAppID,
+        endpoint,
+        region,
+        user_name,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Framework :: AsyncIO",
 ]
-
 dependencies = [
     "aiohttp>=3.11.11",
     "aiomqtt>=2.3.0",
@@ -39,13 +38,23 @@ dependencies = [
     "puremagic>=1.30",
 ]
 
+[project.optional-dependencies]
+redis = ["redis>=5.0.0"]
+
 [dependency-groups]
 dev = [
     "sphinx>=8.1.3",
     "sphinx-rtd-theme>=3.0.2",
     "furo>=2024.8.6",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.25.0",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["fbchat_muqit"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
 

--- a/tests/test_event_decorator.py
+++ b/tests/test_event_decorator.py
@@ -1,0 +1,23 @@
+from fbchat_muqit.events.dispatcher import EventDispatcher, EventType
+
+
+def test_event_decorator_autodetect_from_function_name():
+    dispatcher = EventDispatcher()
+
+    @dispatcher.event
+    async def on_message(message):
+        return
+
+    assert EventType.MESSAGE in dispatcher._event_listeners
+    assert on_message in dispatcher._event_listeners[EventType.MESSAGE]
+
+
+def test_event_decorator_explicit_event_type():
+    dispatcher = EventDispatcher()
+
+    @dispatcher.event(EventType.PRESENCE)
+    async def on_presence(event):
+        return
+
+    assert EventType.PRESENCE in dispatcher._event_listeners
+    assert on_presence in dispatcher._event_listeners[EventType.PRESENCE]

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -1,0 +1,97 @@
+"""Tests for ClientManager and session storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fbchat_muqit.events.dispatcher import EventType
+from fbchat_muqit.manager import ClientManager
+from fbchat_muqit.storage.json_store import JsonSessionStorage
+
+
+@pytest.mark.asyncio
+async def test_manager_event_routing_invokes_handler(tmp_path: Path) -> None:
+    mgr = ClientManager(storage_dir=str(tmp_path))
+    received: list[str] = []
+
+    @mgr.event(client_id="acc1", event=EventType.MESSAGE)
+    async def _on_message(msg: str) -> None:
+        received.append(msg)
+
+    await mgr._route_manager_event("acc1", EventType.MESSAGE, "hello")
+    assert received == ["hello"]
+
+
+@pytest.mark.asyncio
+async def test_manager_event_isolation(tmp_path: Path) -> None:
+    mgr = ClientManager(storage_dir=str(tmp_path))
+    acc1: list[str] = []
+
+    @mgr.event(client_id="acc1", event=EventType.MESSAGE)
+    async def _h(msg: str) -> None:
+        acc1.append(msg)
+
+    await mgr._route_manager_event("acc2", EventType.MESSAGE, "x")
+    assert acc1 == []
+
+
+@pytest.mark.asyncio
+async def test_start_stop_all(tmp_path: Path) -> None:
+    mgr = ClientManager(storage_dir=str(tmp_path))
+    m = MagicMock()
+    m.start = AsyncMock()
+    m.start_listening = AsyncMock()
+    m.stop_listening = AsyncMock()
+    mgr.clients["x"] = m  # type: ignore[assignment]
+    await mgr.start_all()
+    m.start.assert_awaited_once()
+    m.start_listening.assert_awaited_once()
+    await mgr.stop_all()
+    m.stop_listening.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_broadcast(tmp_path: Path) -> None:
+    mgr = ClientManager(storage_dir=str(tmp_path))
+    a = MagicMock()
+    a._state = MagicMock()
+    a.send_message = AsyncMock()
+    mgr.clients["u1"] = a  # type: ignore[assignment]
+    await mgr.broadcast("hi", "12345")
+    a.send_message.assert_awaited_once_with("hi", "12345")
+
+
+@pytest.mark.asyncio
+async def test_json_session_storage_roundtrip(tmp_path: Path) -> None:
+    store = JsonSessionStorage(tmp_path)
+    snap = {"version": 1, "cookies": [{"name": "c_user", "value": "1", "path": "/"}]}
+    await store.save("c1", snap)
+    loaded = await store.load("c1")
+    assert loaded == snap
+
+
+@pytest.mark.asyncio
+async def test_add_client_restore_from_storage(tmp_path: Path) -> None:
+    snap = {"version": 1, "cookies": [{"name": "c_user", "value": "1", "path": "/"}]}
+    store = JsonSessionStorage(tmp_path)
+    await store.save("u1", snap)
+
+    mock_state = MagicMock()
+    with patch(
+        "fbchat_muqit.manager.State.from_cookie_list", new_callable=AsyncMock
+    ) as fc:
+        fc.return_value = mock_state
+        with patch("fbchat_muqit.manager.Client") as Ctor:
+            inst = MagicMock()
+            inst._manager_route = None
+            inst._manager_client_id = ""
+            Ctor.return_value = inst
+            mgr = ClientManager(storage=store)
+            await mgr.add_client("u1", "dummy.json", restore_from_storage=True)
+            fc.assert_awaited_once()
+            Ctor.assert_called_once()
+            kw = Ctor.call_args.kwargs
+            assert kw.get("initial_state") is mock_state

--- a/tests/test_message_parser_correctness.py
+++ b/tests/test_message_parser_correctness.py
@@ -1,0 +1,84 @@
+from types import SimpleNamespace
+
+from fbchat_muqit.events.dispatcher import EventDispatcher
+from fbchat_muqit.models.attachment import AttachmentType, FileAttachment
+from fbchat_muqit.models.deltas.custom_type import MentionType, Value
+from fbchat_muqit.models.deltas.delta_wrapper import NewMessageDelta
+from fbchat_muqit.models.deltas.parser import MessageParser
+from fbchat_muqit.models.message import MessageType
+from fbchat_muqit.models.thread import ThreadFolder, ThreadType
+
+
+def _make_message_metadata(*, folder: str) -> SimpleNamespace:
+    """Avoid constructing :class:`MessageData` (msgspec reserves ``id`` for struct metadata)."""
+    return SimpleNamespace(
+        id="mid",
+        sender_id="123",
+        folder=Value(folder),
+        timestamp=1710000000000,
+        thread_id=Value("456"),
+        adminText="",
+        unsendType="unknown",
+    )
+
+
+def test_attachment_file_maps_to_message_type_file():
+    dispatcher = EventDispatcher()
+    parser = MessageParser(dispatcher.logger)
+    assert parser._attach_to_message[AttachmentType.FILE] == MessageType.FILE
+
+
+def test_parse_message_uses_folder_and_heuristic_thread_type():
+    dispatcher = EventDispatcher()
+    parser = MessageParser(dispatcher.logger)
+
+    delta_user = NewMessageDelta(
+        messageMetadata=_make_message_metadata(folder="ARCHIVE"),  # type: ignore[arg-type]
+        body="hi",
+        attachments=[],
+        mentions=MentionType(),
+        participants=(1, 2),
+    )
+    msg_user = parser.parse_message(delta_user)
+    assert msg_user.thread_folder == ThreadFolder.ARCHIVE
+    assert msg_user.thread_type == ThreadType.USER
+
+    delta_group = NewMessageDelta(
+        messageMetadata=_make_message_metadata(folder="INBOX"),  # type: ignore[arg-type]
+        body="hi",
+        attachments=[],
+        mentions=MentionType(),
+        participants=(1, 2, 3, 4),
+    )
+    msg_group = parser.parse_message(delta_group)
+    assert msg_group.thread_folder == ThreadFolder.INBOX
+    assert msg_group.thread_type == ThreadType.GROUP
+
+
+def test_parse_message_file_attachment_sets_message_type_file():
+    dispatcher = EventDispatcher()
+    parser = MessageParser(dispatcher.logger)
+
+    file_attachment = FileAttachment(
+        download_url="https://example.com/file.bin",
+    )
+
+    class _Mercury:
+        extensible_attachment = None
+        sticker_attachment = None
+        blob_attachment = file_attachment
+
+    class _Raw:
+        mercury = _Mercury()
+        id = "att1"
+
+    delta = NewMessageDelta(
+        messageMetadata=_make_message_metadata(folder="INBOX"),  # type: ignore[arg-type]
+        body=None,
+        attachments=[_Raw()],  # type: ignore[list-item]
+        mentions=MentionType(),
+        participants=(1, 2),
+    )
+
+    msg = parser.parse_message(delta)
+    assert msg.message_type == MessageType.FILE

--- a/uv.lock
+++ b/uv.lock
@@ -22,6 +22,7 @@ wheels = [
 name = "aenum"
 version = "3.1.16"
 source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/09/7a/61ed58e8be9e30c3fe518899cc78c284896d246d51381bab59b5db11e1f3/aenum-3.1.16.tar.gz", hash = "sha256:bfaf9589bdb418ee3a986d85750c7318d9d2839c1b1a1d6fe8fc53ec201cf140", size = 137693, upload-time = "2026-01-12T22:34:38.819Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e3/52/6ad8f63ec8da1bf40f96996d25d5b650fdd38f5975f8c813732c47388f18/aenum-3.1.16-py3-none-any.whl", hash = "sha256:9035092855a98e41b66e3d0998bd7b96280e85ceb3a04cc035636138a1943eaf", size = 165627, upload-time = "2025-04-25T03:17:58.89Z" },
 ]
@@ -239,6 +240,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "beautifulsoup4"
 version = "4.14.2"
 source = { registry = "https://pypi.org/simple" }
@@ -401,8 +411,20 @@ wheels = [
 ]
 
 [[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
 name = "fbchat-muqit"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "aenum" },
@@ -417,9 +439,16 @@ dependencies = [
     { name = "yarl" },
 ]
 
+[package.optional-dependencies]
+redis = [
+    { name = "redis" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "furo" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "sphinx", version = "8.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "sphinx", version = "8.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "sphinx-rtd-theme" },
@@ -436,12 +465,16 @@ requires-dist = [
     { name = "filetype", specifier = ">=1.2.0" },
     { name = "msgspec", specifier = ">=0.19.0" },
     { name = "puremagic", specifier = ">=1.30" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=5.0.0" },
     { name = "yarl", specifier = ">=1.18.3" },
 ]
+provides-extras = ["redis"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "furo", specifier = ">=2024.8.6" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.25.0" },
     { name = "sphinx", specifier = ">=8.1.3" },
     { name = "sphinx-rtd-theme", specifier = ">=3.0.2" },
 ]
@@ -609,6 +642,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a7/84/62473fb57d61e31fef6e36d64a179c8781605429fd927b5dd608c997be31/imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a", size = 1280026, upload-time = "2022-07-01T12:21:05.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ff/62/85c4c919272577931d407be5ba5d71c20f0b616d31a0befe0ae45bb79abd/imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b", size = 8769, upload-time = "2022-07-01T12:21:02.467Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -901,6 +943,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "propcache"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1033,6 +1084,38 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "python-socks"
 version = "2.7.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1044,6 +1127,18 @@ wheels = [
 [package.optional-dependencies]
 asyncio = [
     { name = "async-timeout", marker = "python_full_version < '3.11'" },
+]
+
+[[package]]
+name = "redis"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-timeout", marker = "python_full_version < '3.11.3'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/82/4d1a5279f6c1251d3d2a603a798a1137c657de9b12cfc1fba4858232c4d2/redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034", size = 4928081, upload-time = "2026-03-06T18:18:16.287Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/28/84e57fce7819e81ec5aa1bd31c42b89607241f4fb1a3ea5b0d2dbeaea26c/redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364", size = 404379, upload-time = "2026-03-06T18:18:14.583Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### What’s new

- Multi-account `ClientManager` (parallel sessions)
- Persistent session storage (restore without login)
- Event routing by `client_id`

### Fixes

- Fixed dispatcher task leak on shutdown
- Fixed `@client.event` decorator usage
- Fixed message parsing (attachments + thread context)
- Improved MQTT error handling (no silent failures)

### Why this matters

- Enables production-scale automation (multiple accounts)
- Prevents async task leaks and shutdown hangs
- Fixes incorrect message classification bugs

### Before vs After

- Before: single-account, unstable shutdown, incorrect parsing
- After: multi-account, stable lifecycle, correct event/message handling

### Tests

- Added tests for:
  - event decorator
  - message parsing
  - multi-client manager

---
Made with Cursor.